### PR TITLE
Fix Referee playMove return value

### DIFF
--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -119,6 +119,7 @@ setBoard(() => {
   );
 
   if (moveWasPlayed) {
+    playedMoveIsValid = true;
     moveSound.play();
     clonedBoard.totalTurns += 1;
 


### PR DESCRIPTION
## Summary
- mark moves as valid only when `playMove` actually moved the piece

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(script missing)*

------
https://chatgpt.com/codex/tasks/task_e_68455b0369108330bfc34159935b1a0e