### PR TITLE
Randomize player colors

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -96,8 +96,10 @@ wss.on("connection", (ws) => {
       // Starte Spiel erst, wenn genau 2 unterschiedliche Clients verbunden sind
       if (!game.started && game.players.length === 2) {
         game.started = true;
+        const colors = ["white", "black"];
+        colors.sort(() => Math.random() - 0.5);
         game.players.forEach((player, idx) => {
-          const color = idx === 0 ? "white" : "black";
+          const color = colors[idx];
           player.send(
             JSON.stringify({
               type: "start",


### PR DESCRIPTION
## Summary
- randomize player colors when starting a game

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: `next: not found`)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68455f1832288330acc23677cc527f81