### PR TITLE
Store and restore player color

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -18,6 +18,13 @@ export default function GamePage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const stored = localStorage.getItem("worldchess-color");
+    if (stored === "white" || stored === "black") {
+      setPlayerColor(stored);
+    }
+  }, []);
+
+  useEffect(() => {
     connectSocket();
     // HTTP-Fallback
     fetch(`http://localhost:3001/games/${id}`)

--- a/app/waiting-room/[id]/page.tsx
+++ b/app/waiting-room/[id]/page.tsx
@@ -16,6 +16,9 @@ export default function WaitingRoom() {
 
     const off = onMessage((msg) => {
       if (msg.type === "start") {
+        if (msg.color) {
+          localStorage.setItem("worldchess-color", msg.color);
+        }
         router.push(`/game/${id}`);
       }
       if (msg.type === "error") {


### PR DESCRIPTION
## Summary
- store chosen color in local storage when waiting room receives the start message
- initialize `playerColor` in game page from local storage

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68455dc027d88330b97331d490dff579