### PR TITLE
Fix board orientation for black

### DIFF
--- a/src/components/Chessboard/Chessboard.css
+++ b/src/components/Chessboard/Chessboard.css
@@ -63,12 +63,6 @@
 .modal > .modal-body > .checkmate-body > button:hover {
   cursor: pointer;
 }
-#chessboard.rotate-board {
-  transform: rotate(180deg);
-}
-/* Rückgängig Rotation einzelner Tiles */
-#chessboard.rotate-board > * {
-  transform: rotate(180deg);
-}
+
 
 

--- a/src/components/Chessboard/Chessboard.tsx
+++ b/src/components/Chessboard/Chessboard.tsx
@@ -100,7 +100,6 @@ console.log("Chessboard – playerColor:", playerColor);
     <div
       id="chessboard"
       ref={chessboardRef}
-      className={playerColor === "black" ? "rotate-board" : ""}
       onMouseMove={movePiece}
       onMouseDown={grabPiece}
       onMouseUp={dropPiece}


### PR DESCRIPTION
## Summary
- remove rotate-board class and CSS
- rely on tile order to flip board for black players

## Testing
- `npx tsc` *(fails: cannot redeclare export and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845be3db70c8330b74b02e1c9540627