### PR TITLE
Add FAQ page with back buttons

### DIFF
--- a/app/create-game/page.tsx
+++ b/app/create-game/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { connectSocket, sendMessage, onMessage } from "@/websocket";
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 export default function CreateGamePage() {
   const [timeControl, setTimeControl] = useState("15+10");
@@ -95,6 +96,12 @@ export default function CreateGamePage() {
       >
         Spiel erstellen
       </button>
+      <Link
+        href="/"
+        className="px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded text-white font-semibold"
+      >
+        Zurück
+      </Link>
     </div>
   );
 }

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+import Link from "next/link";
+
+export default function FAQPage() {
+  return (
+    <div className="min-h-screen bg-blue-900 text-white p-8 flex flex-col items-center space-y-6">
+      <h1 className="text-2xl font-bold">FAQ</h1>
+      <p className="max-w-prose text-center">
+        Hier findest du Antworten auf häufig gestellte Fragen rund um WorldChess.
+      </p>
+      <Link
+        href="/"
+        className="mt-8 px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded text-white font-semibold"
+      >
+        Zurück
+      </Link>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,12 +31,6 @@ export default function Page() {
         >
           Wartende Spiele
         </Link>
-        <Link
-        href="/singleplayer"
-        className="block w-64 bg-green-600 hover:bg-green-700 text-white text-lg font-semibold py-3 px-6 rounded-lg text-center"
-      >
-        Einzelspiel starten
-      </Link>
       </div>
     </div>
   );

--- a/app/waiting-games/page.tsx
+++ b/app/waiting-games/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { connectSocket, onMessage } from "@/websocket";
+import Link from "next/link";
 
 type WaitingGame = { id: string; timeControl: string; stake: number; };
 
@@ -30,20 +31,33 @@ export default function WaitingGamesPage() {
   const handleJoin = (g: WaitingGame) => window.location.href = `/waiting-room/${g.id}`;
 
   return (
-    <div>
-      <h1>Wartende Spiele</h1>
+    <div className="min-h-screen bg-blue-900 text-white p-8 flex flex-col items-center space-y-4">
+      <h1 className="text-2xl font-bold">Wartende Spiele</h1>
       {games.length === 0 ? (
         <p>Keine Spiele verfügbar.</p>
       ) : (
-        <ul>
+        <ul className="space-y-2">
           {games.map(g => (
-            <li key={g.id}>
-              <strong>{g.timeControl}</strong> – {g.stake} WLD
-              <button onClick={() => handleJoin(g)}>Beitreten</button>
+            <li key={g.id} className="flex items-center gap-4">
+              <span className="flex-1">
+                <strong>{g.timeControl}</strong> – {g.stake} WLD
+              </span>
+              <button
+                className="px-4 py-2 bg-green-600 hover:bg-green-700 rounded text-white"
+                onClick={() => handleJoin(g)}
+              >
+                Beitreten
+              </button>
             </li>
           ))}
         </ul>
       )}
+      <Link
+        href="/"
+        className="mt-6 px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded text-white font-semibold"
+      >
+        Zurück
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add /faq route with simple FAQ page
- remove the singleplayer link from the main menu
- add navigation back button to Create Game and Waiting Games
- add back button on new FAQ page

## Testing
- `npm run lint` *(fails: various eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845c013cea883309ba935198de34eb5