### PR TITLE
Ignore backup files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,9 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: ["**/*_backup.tsx", "**/*_backup.css"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,9 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "**/*_backup.tsx",
+    "**/*_backup.css"
+  ]
 }


### PR DESCRIPTION
## Summary
- exclude backup TSX/CSS files from TypeScript compilation
- tell ESLint to ignore backup files

## Testing
- `npm run lint` *(fails: unused variables and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_6845c44bf9548330a19b4003d4c0713e