### PR TITLE
Add state-request handling

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -70,6 +70,22 @@ wss.on("connection", (ws) => {
       return console.error("Ungültiges JSON:", message);
     }
 
+    if (data.type === "state-request") {
+      const game = games[data.gameId];
+      if (game) {
+        ws.send(
+          JSON.stringify({
+            type: "state",
+            fen: game.board.fen(),
+            moves: game.moves,
+          })
+        );
+      } else {
+        ws.send(JSON.stringify({ type: "error", message: "Spiel nicht gefunden" }));
+      }
+      return;
+    }
+
     // Neues Spiel anlegen
     if (data.type === "new-game") {
       const { id, timeControl, stake } = data.payload;

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -6,7 +6,12 @@ export function connectSocket() {
   if (!socket || socket.readyState === WebSocket.CLOSED) {
     socket = new WebSocket(WS_URL);
     console.log("Connecting to WebSocket...");
-    socket.onopen = () => console.log("[WebSocket] verbunden");
+    socket.onopen = () => {
+      console.log("[WebSocket] verbunden");
+      if (currentGameId) {
+        sendMessage({ type: "state-request", gameId: currentGameId });
+      }
+    };
     socket.onclose = () => {
       console.log("[WebSocket] getrennt");
       socket = null;


### PR DESCRIPTION
## Summary
- auto-send state-request after reconnects in `websocket.ts`
- add a `state-request` handler in `server.ts`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b45bf5b08330b0e38057f9489548