### PR TITLE
Fix extra dependency array in ChessClock

### DIFF
--- a/src/components/Clock/ChessClock.tsx
+++ b/src/components/Clock/ChessClock.tsx
@@ -82,7 +82,6 @@ export default function ChessClock({
     setActive(newActive);
     prevTurns.current = totalTurns;
   }, [totalTurns, currentTurn, gameOver]);
-  }, [totalTurns, currentTurn]);
 
 
   return (


### PR DESCRIPTION
## Summary
- fix a syntax error in ChessClock.tsx
- run tests

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685279cc68088330b9308ee820e74b0a