### PR TITLE
Use env variables for URLs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_WS_URL=ws://localhost:8080

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ pnpm dev
 bun dev
 ```
 
+Create a `.env.local` file based on `.env.local.example` and adjust the API and WebSocket URLs if necessary:
+
+```bash
+cp .env.local.example .env.local
+```
+
+The file defines the following variables used by the client:
+
+```env
+NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_WS_URL=ws://localhost:8080
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -28,7 +28,7 @@ export default function GamePage() {
     connectSocket();
     requestState(id as string);
     // HTTP-Fallback
-    fetch(`http://localhost:3001/games/${id}`)
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/games/${id}`)
       .then(res => {
         if (!res.ok) throw new Error("Spiel nicht gefunden");
         return res.json();

--- a/app/waiting-games/page.tsx
+++ b/app/waiting-games/page.tsx
@@ -10,7 +10,7 @@ export default function WaitingGamesPage() {
 
   useEffect(() => {
     // Initiale Liste via HTTP
-    fetch("http://localhost:3001/games")
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/games`)
       .then(res => res.json())
       .then((data: WaitingGame[]) => setGames(data))
       .catch(console.error);

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -1,6 +1,6 @@
 let socket: WebSocket | null = null;
 let currentGameId: string | null = null;
-const WS_URL = "ws://localhost:8080";
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8080";
 
 export function connectSocket() {
   if (!socket || socket.readyState === WebSocket.CLOSED) {


### PR DESCRIPTION
## Summary
- allow configuring API and WebSocket URLs via `.env`
- use env variables in WebSocket client
- use env variables in waiting-games and game pages
- document env setup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685284e89344833095f513430320fff6