### PR TITLE
Fallback API_URL for game pages

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -4,6 +4,8 @@ import { useParams } from "next/navigation";
 import { connectSocket, onMessage, requestState } from "@/websocket";
 import App from "../../../src/App";
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
 interface Game {
   id: string;
   timeControl: string;
@@ -28,7 +30,7 @@ export default function GamePage() {
     connectSocket();
     requestState(id as string);
     // HTTP-Fallback
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/games/${id}`)
+    fetch(`${API_URL}/games/${id}`)
       .then(res => {
         if (!res.ok) throw new Error("Spiel nicht gefunden");
         return res.json();

--- a/app/waiting-games/page.tsx
+++ b/app/waiting-games/page.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 import { connectSocket, onMessage } from "@/websocket";
 import Link from "next/link";
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
 type WaitingGame = { id: string; timeControl: string; stake: number; };
 
 export default function WaitingGamesPage() {
@@ -10,7 +12,7 @@ export default function WaitingGamesPage() {
 
   useEffect(() => {
     // Initiale Liste via HTTP
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/games`)
+    fetch(`${API_URL}/games`)
       .then(res => res.json())
       .then((data: WaitingGame[]) => setGames(data))
       .catch(console.error);


### PR DESCRIPTION
## Summary
- allow pages to work when NEXT_PUBLIC_API_URL is missing
- default to `http://localhost:3001` when env variable is undefined

## Testing
- `npm test`
- `npm run lint` *(fails: Game is defined but never used, and many other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68528ffda08c8330a0b89f90cd20a3ce