### PR TITLE
Fix state event game handling

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -47,8 +47,10 @@ export default function GamePage() {
         console.log(localStorage.getItem("worldchess-color"));
       }
       if (msg.type === "state") {
-        const gameData = msg.game ?? msg.payload ?? msg;
-        setGame(gameData);
+        if (msg.game || msg.payload) {
+          const gameData = msg.game ?? msg.payload;
+          setGame(gameData);
+        }
         if (msg.color) {
           setPlayerColor(msg.color);
           localStorage.setItem("worldchess-color", msg.color);


### PR DESCRIPTION
## Summary
- update `onMessage` handler in app/game/[id]/page.tsx
  - only update game when `game` or `payload` is present in a `state` message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68529719eef083308e45e9e269d90aca