### PR TITLE
Refresh board on server errors

### DIFF
--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -20,7 +20,7 @@ import {
 import { PieceType, TeamType } from "../../Types";
 import Chessboard from "../Chessboard/Chessboard";
 import { Howl } from "howler";
-import { sendMove, onMove, onState } from "@/websocket";
+import { sendMove, onMove, onState, onError, requestState } from "@/websocket";
 import ChessClock from "../Clock/ChessClock";
 
 
@@ -119,12 +119,20 @@ useEffect(() => {
     });
   };
 
+  const handleError = (msg: any) => {
+    // Refresh the board state in case we desynced
+    requestState(initialGame.id);
+    alert(msg.message || "An error occurred");
+  };
+
   const unsubMove = onMove(applyMove);
   const unsubState = onState(applyState);
+  const unsubError = onError(handleError);
 
   return () => {
     unsubMove();
     unsubState();
+    unsubError();
   };
 }, []);
 

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -63,9 +63,14 @@ export function onState(callback: (state: any) => void): () => void {
   });
 }
 
-export function onInvalidMove(callback: (msg: any) => void): () => void {
+/**
+ * Register a callback for error messages coming from the server.
+ * Errors can occur for various reasons such as invalid moves or
+ * trying to play out of turn.
+ */
+export function onError(callback: (msg: any) => void): () => void {
   return onMessage((msg) => {
-    if (msg.type === "invalid-move") {
+    if (msg.type === "error") {
       callback(msg);
     }
   });


### PR DESCRIPTION
## Summary
- expose `onError` handler in `websocket.ts`
- listen for server errors in `Referee` and request board state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852afe3246c83308ee2421b0b23ed48