### PR TITLE
Fix promotion capturing bug

### DIFF
--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -21,6 +21,7 @@ import { PieceType, TeamType } from "../../Types";
 import Chessboard from "../Chessboard/Chessboard";
 import { Howl } from "howler";
 import { sendMove, onMove, onState, onError, requestState } from "@/websocket";
+import { symbolToPieceType } from "@/utils/pieceSymbols";
 import ChessClock from "../Clock/ChessClock";
 
 
@@ -66,7 +67,7 @@ export default function Referee({ initialGame, playerColor }: RefereeProps) {
   }
 
 useEffect(() => {
-  const applyMove = (move: { from: { x: number; y: number }; to: { x: number; y: number }; promotion?: PieceType }) => {
+  const applyMove = (move: { from: { x: number; y: number }; to: { x: number; y: number }; promotion?: string }) => {
     setBoard((currentBoard) => {
       const clonedBoard = currentBoard.clone();
 
@@ -77,13 +78,16 @@ useEffect(() => {
       if (piece) {
         clonedBoard.playMove(false, true, piece, new Position(move.to.x, move.to.y));
         if (move.promotion) {
-          clonedBoard.pieces = clonedBoard.pieces.map((p) =>
-            p.position.x === move.to.x &&
-            p.position.y === move.to.y &&
-            p.team === piece.team
-              ? new Piece(p.position.clone(), move.promotion!, p.team, true)
-              : p
-          );
+          const promotionType = symbolToPieceType(move.promotion);
+          if (promotionType) {
+            clonedBoard.pieces = clonedBoard.pieces.map((p) =>
+              p.position.x === move.to.x &&
+              p.position.y === move.to.y &&
+              p.team === piece.team
+                ? new Piece(p.position.clone(), promotionType, p.team, true)
+                : p
+            );
+          }
         }
         clonedBoard.totalTurns += 1;
         clonedBoard.calculateAllMoves();
@@ -103,13 +107,16 @@ useEffect(() => {
         if (piece) {
           clonedBoard.playMove(false, true, piece, new Position(m.to.x, m.to.y));
           if (m.promotion) {
-            clonedBoard.pieces = clonedBoard.pieces.map((p) =>
-              p.position.x === m.to.x &&
-              p.position.y === m.to.y &&
-              p.team === piece.team
-                ? new Piece(p.position.clone(), m.promotion!, p.team, true)
-                : p
-            );
+            const promotionType = symbolToPieceType(m.promotion);
+            if (promotionType) {
+              clonedBoard.pieces = clonedBoard.pieces.map((p) =>
+                p.position.x === m.to.x &&
+                p.position.y === m.to.y &&
+                p.team === piece.team
+                  ? new Piece(p.position.clone(), promotionType, p.team, true)
+                  : p
+              );
+            }
           }
           clonedBoard.totalTurns += 1;
           clonedBoard.calculateAllMoves();
@@ -308,18 +315,20 @@ function isStalemate(board: Board, team: TeamType): boolean {
   }
 
   function promotePawn(pieceType: PieceType) {
-    if (promotionPawn === undefined) {
+    if (!promotionPawn || !pendingPromotion) {
       return;
     }
 
+    const { from, to } = pendingPromotion;
+
     setBoard((previousBoard) => {
-      const clonedBoard = board.clone();
+      const clonedBoard = previousBoard.clone();
       clonedBoard.pieces = clonedBoard.pieces.reduce((results, piece) => {
-        if (piece.samePiecePosition(promotionPawn)) {
-          results.push(
-            new Piece(piece.position.clone(), pieceType, piece.team, true)
-          );
-        } else {
+        if (piece.position.x === from.x && piece.position.y === from.y && piece.team === promotionPawn.team) {
+          // replace the moving pawn with the promoted piece at the destination
+          results.push(new Piece(to.clone(), pieceType, piece.team, true));
+        } else if (!(piece.position.x === to.x && piece.position.y === to.y)) {
+          // discard any captured piece on the destination square
           results.push(piece);
         }
         return results;
@@ -330,14 +339,12 @@ function isStalemate(board: Board, team: TeamType): boolean {
       return clonedBoard;
     });
 
-    if (pendingPromotion) {
-      sendMove({
-        from: { x: pendingPromotion.from.x, y: pendingPromotion.from.y },
-        to: { x: pendingPromotion.to.x, y: pendingPromotion.to.y },
-        promotion: pieceType,
-      });
-      setPendingPromotion(null);
-    }
+    sendMove({
+      from: { x: from.x, y: from.y },
+      to: { x: to.x, y: to.y },
+      promotion: pieceType,
+    });
+    setPendingPromotion(null);
 
     modalRef.current?.classList.add("hidden");
   }

--- a/src/utils/pieceSymbols.ts
+++ b/src/utils/pieceSymbols.ts
@@ -1,0 +1,38 @@
+import { PieceType } from "../Types";
+
+export function pieceTypeToSymbol(piece: PieceType): string {
+  switch (piece) {
+    case PieceType.KNIGHT:
+      return 'n';
+    case PieceType.BISHOP:
+      return 'b';
+    case PieceType.ROOK:
+      return 'r';
+    case PieceType.QUEEN:
+      return 'q';
+    case PieceType.KING:
+      return 'k';
+    case PieceType.PAWN:
+    default:
+      return 'p';
+  }
+}
+
+export function symbolToPieceType(symbol: string): PieceType | undefined {
+  switch (symbol.toLowerCase()) {
+    case 'n':
+      return PieceType.KNIGHT;
+    case 'b':
+      return PieceType.BISHOP;
+    case 'r':
+      return PieceType.ROOK;
+    case 'q':
+      return PieceType.QUEEN;
+    case 'k':
+      return PieceType.KING;
+    case 'p':
+      return PieceType.PAWN;
+    default:
+      return undefined;
+  }
+}

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -78,10 +78,16 @@ export function onError(callback: (msg: any) => void): () => void {
 
 // Neuer Export: sendMove
 import { PieceType } from "./Types";
+import { pieceTypeToSymbol } from "./utils/pieceSymbols";
 
 export function sendMove(move: { from: { x: number; y: number }; to: { x: number; y: number }; promotion?: PieceType }) {
   if (!currentGameId) return;
-  sendMessage({ type: "move", gameId: currentGameId, payload: move });
+  const payload = {
+    from: move.from,
+    to: move.to,
+    promotion: move.promotion ? pieceTypeToSymbol(move.promotion) : undefined,
+  };
+  sendMessage({ type: "move", gameId: currentGameId, payload });
 }
 
 export function requestState(gameId: string) {


### PR DESCRIPTION
## Summary
- ensure promoting a pawn replaces the pawn rather than the captured piece
- send promotion piece as chess.js notation
- handle notation when applying moves

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852bdbae91483309a9d5fc3e8f8e73b