### PR TITLE
Handle en passant and castling from server moves

### DIFF
--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -76,7 +76,20 @@ useEffect(() => {
       );
 
       if (piece) {
-        clonedBoard.playMove(false, true, piece, new Position(move.to.x, move.to.y));
+        const destination = new Position(move.to.x, move.to.y);
+        let enPassant = false;
+        if (
+          piece.isPawn &&
+          Math.abs(move.to.x - move.from.x) === 1 &&
+          move.to.y - move.from.y === (piece.team === TeamType.OUR ? 1 : -1) &&
+          !clonedBoard.pieces.some(
+            (p) => p.position.x === move.to.x && p.position.y === move.to.y
+          )
+        ) {
+          enPassant = true;
+        }
+
+        clonedBoard.playMove(enPassant, true, piece, destination);
         if (move.promotion) {
           const promotionType = symbolToPieceType(move.promotion);
           if (promotionType) {
@@ -105,7 +118,20 @@ useEffect(() => {
           (p) => p.position.x === m.from.x && p.position.y === m.from.y
         );
         if (piece) {
-          clonedBoard.playMove(false, true, piece, new Position(m.to.x, m.to.y));
+          const destination = new Position(m.to.x, m.to.y);
+          let enPassant = false;
+          if (
+            piece.isPawn &&
+            Math.abs(m.to.x - m.from.x) === 1 &&
+            m.to.y - m.from.y === (piece.team === TeamType.OUR ? 1 : -1) &&
+            !clonedBoard.pieces.some(
+              (p) => p.position.x === m.to.x && p.position.y === m.to.y
+            )
+          ) {
+            enPassant = true;
+          }
+
+          clonedBoard.playMove(enPassant, true, piece, destination);
           if (m.promotion) {
             const promotionType = symbolToPieceType(m.promotion);
             if (promotionType) {

--- a/src/models/Board.ts
+++ b/src/models/Board.ts
@@ -162,7 +162,41 @@ export class Board {
       p.samePosition(destination)
     );
 
-    // If the move is a castling move do this
+    // Castling when the king moves two squares horizontally to an empty square
+    if (
+      playedPiece.isKing &&
+      !destinationPiece &&
+      Math.abs(destination.x - playedPiece.position.x) === 2 &&
+      destination.y === playedPiece.position.y
+    ) {
+      const direction = destination.x - playedPiece.position.x > 0 ? 1 : -1;
+      const rookStartX = direction === 1 ? 7 : 0;
+      const rook = this.pieces.find(
+        (p) =>
+          p.isRook &&
+          p.team === playedPiece.team &&
+          p.position.y === playedPiece.position.y &&
+          p.position.x === rookStartX
+      );
+      if (rook) {
+        this.pieces = this.pieces.map((p) => {
+          if (p.samePiecePosition(playedPiece)) {
+            p.position.x = destination.x;
+            p.hasMoved = true;
+          } else if (p.samePiecePosition(rook)) {
+            p.position.x = destination.x - direction;
+            p.hasMoved = true;
+          }
+
+          return p;
+        });
+
+        this.calculateAllMoves();
+        return true;
+      }
+    }
+
+    // Legacy castling detection when moving onto the rook
     if (
       playedPiece.isKing &&
       destinationPiece?.isRook &&
@@ -174,8 +208,10 @@ export class Board {
       this.pieces = this.pieces.map((p) => {
         if (p.samePiecePosition(playedPiece)) {
           p.position.x = newKingXPosition;
+          p.hasMoved = true;
         } else if (p.samePiecePosition(destinationPiece)) {
           p.position.x = newKingXPosition - direction;
+          p.hasMoved = true;
         }
 
         return p;

--- a/tests/server-moves.test.ts
+++ b/tests/server-moves.test.ts
@@ -1,0 +1,59 @@
+import { Board } from '@/models/Board';
+import { Pawn } from '@/models/Pawn';
+import { Piece } from '@/models/Piece';
+import { Position } from '@/models/Position';
+import { PieceType, TeamType } from '@/Types';
+
+describe('server move application', () => {
+  test('en passant capture removes the pawn', () => {
+    const whitePawn = new Pawn(new Position(4, 4), TeamType.OUR, false);
+    const blackPawn = new Pawn(new Position(5, 6), TeamType.OPPONENT, false);
+    const whiteKing = new Piece(new Position(0, 0), PieceType.KING, TeamType.OUR, false);
+    const blackKing = new Piece(new Position(7, 7), PieceType.KING, TeamType.OPPONENT, false);
+    const board = new Board([whitePawn, blackPawn, whiteKing, blackKing], 1);
+    board.calculateAllMoves();
+
+    // black pawn double step
+    board.playMove(false, true, blackPawn, new Position(5, 4));
+    board.totalTurns += 1;
+    board.calculateAllMoves();
+
+    const move = { from: { x: 4, y: 4 }, to: { x: 5, y: 5 } };
+    const piece = board.pieces.find(
+      (p) => p.position.x === move.from.x && p.position.y === move.from.y
+    )!;
+    const enPassant =
+      piece.isPawn &&
+      Math.abs(move.to.x - move.from.x) === 1 &&
+      move.to.y - move.from.y === (piece.team === TeamType.OUR ? 1 : -1) &&
+      !board.pieces.some(
+        (p) => p.position.x === move.to.x && p.position.y === move.to.y
+      );
+
+    board.playMove(enPassant, true, piece, new Position(move.to.x, move.to.y));
+
+    expect(board.pieces.some((p) => p.position.x === 5 && p.position.y === 4)).toBe(
+      false
+    );
+    const ourPawn = board.pieces.find((p) => p.team === TeamType.OUR)!;
+    expect(ourPawn.position.x).toBe(5);
+    expect(ourPawn.position.y).toBe(5);
+  });
+
+  test('castling moves king and rook', () => {
+    const king = new Piece(new Position(4, 0), PieceType.KING, TeamType.OUR, false);
+    const rook = new Piece(new Position(7, 0), PieceType.ROOK, TeamType.OUR, false);
+    const blackKing = new Piece(new Position(4, 7), PieceType.KING, TeamType.OPPONENT, false);
+    const board = new Board([king, rook, blackKing], 1);
+    board.calculateAllMoves();
+
+    const piece = board.pieces.find((p) => p.isKing)!;
+    board.playMove(false, true, piece, new Position(6, 0));
+
+    expect(piece.position.x).toBe(6);
+    const movedRook = board.pieces.find((p) => p.isRook)!;
+    expect(movedRook.position.x).toBe(5);
+    expect(piece.hasMoved).toBe(true);
+    expect(movedRook.hasMoved).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- support castling when king moves two squares
- detect en-passant when applying moves from the server
- test en-passant and castling behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531f4c1884833083246eee6c220ae2