### PR TITLE
Add FEN parser and use it for board state

### DIFF
--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -24,6 +24,7 @@ import { sendMove, onMove, onState, onError, requestState } from "@/websocket";
 import { symbolToPieceType } from "@/utils/pieceSymbols";
 import ChessClock from "../Clock/ChessClock";
 
+import { parseFen } from "@/utils/fen";
 
 interface RefereeProps {
   initialGame: {
@@ -110,46 +111,8 @@ useEffect(() => {
     });
   };
 
-  const applyState = (state: { moves: any[] }) => {
-    setBoard(() => {
-      const clonedBoard = initialBoard.clone();
-      for (const m of state.moves) {
-        const piece = clonedBoard.pieces.find(
-          (p) => p.position.x === m.from.x && p.position.y === m.from.y
-        );
-        if (piece) {
-          const destination = new Position(m.to.x, m.to.y);
-          let enPassant = false;
-          if (
-            piece.isPawn &&
-            Math.abs(m.to.x - m.from.x) === 1 &&
-            m.to.y - m.from.y === (piece.team === TeamType.OUR ? 1 : -1) &&
-            !clonedBoard.pieces.some(
-              (p) => p.position.x === m.to.x && p.position.y === m.to.y
-            )
-          ) {
-            enPassant = true;
-          }
-
-          clonedBoard.playMove(enPassant, true, piece, destination);
-          if (m.promotion) {
-            const promotionType = symbolToPieceType(m.promotion);
-            if (promotionType) {
-              clonedBoard.pieces = clonedBoard.pieces.map((p) =>
-                p.position.x === m.to.x &&
-                p.position.y === m.to.y &&
-                p.team === piece.team
-                  ? new Piece(p.position.clone(), promotionType, p.team, true)
-                  : p
-              );
-            }
-          }
-          clonedBoard.totalTurns += 1;
-          clonedBoard.calculateAllMoves();
-        }
-      }
-      return clonedBoard;
-    });
+  const applyState = (state: { fen: string; moves: any[] }) => {
+    setBoard(() => parseFen(state.fen));
   };
 
   const handleError = (msg: any) => {

--- a/src/utils/fen.ts
+++ b/src/utils/fen.ts
@@ -1,0 +1,81 @@
+import { Board } from '../models/Board';
+import { Pawn } from '../models/Pawn';
+import { Piece } from '../models/Piece';
+import { Position } from '../models/Position';
+import { PieceType, TeamType } from '../Types';
+import { symbolToPieceType } from './pieceSymbols';
+
+export function parseFen(fen: string): Board {
+  const [placement, activeColor, castling, enPassant, , fullmove] = fen.split(" ");
+
+  const pieces: Piece[] = [];
+  const rows = placement.split('/');
+
+  for (let row = 0; row < 8; row++) {
+    const y = 7 - row;
+    const rowString = rows[row];
+    let x = 0;
+    for (const char of rowString) {
+      if (char >= '1' && char <= '8') {
+        x += parseInt(char, 10);
+        continue;
+      }
+      const type = symbolToPieceType(char);
+      if (!type) continue;
+      const team = char === char.toUpperCase() ? TeamType.OUR : TeamType.OPPONENT;
+      const pos = new Position(x, y);
+
+      let hasMoved = true;
+      if (type === PieceType.PAWN) {
+        const startRow = team === TeamType.OUR ? 1 : 6;
+        hasMoved = y !== startRow;
+        pieces.push(new Pawn(pos, team, hasMoved));
+      } else {
+        if (type === PieceType.KING) {
+          const startRow = team === TeamType.OUR ? 0 : 7;
+          const rights = team === TeamType.OUR ? castling.includes('K') || castling.includes('Q') : castling.includes('k') || castling.includes('q');
+          hasMoved = !(rights && x === 4 && y === startRow);
+        } else if (type === PieceType.ROOK) {
+          const startRow = team === TeamType.OUR ? 0 : 7;
+          if (team === TeamType.OUR) {
+            if (x === 0 && y === startRow) {
+              hasMoved = !castling.includes('Q');
+            } else if (x === 7 && y === startRow) {
+              hasMoved = !castling.includes('K');
+            }
+          } else {
+            if (x === 0 && y === startRow) {
+              hasMoved = !castling.includes('q');
+            } else if (x === 7 && y === startRow) {
+              hasMoved = !castling.includes('k');
+            }
+          }
+        } else {
+          const startRow = team === TeamType.OUR ? 0 : 7;
+          hasMoved = y !== startRow;
+        }
+        pieces.push(new Piece(pos, type, team, hasMoved));
+      }
+      x += 1;
+    }
+  }
+
+  const full = parseInt(fullmove, 10);
+  const totalTurns = (full - 1) * 2 + (activeColor === 'w' ? 1 : 2);
+  const board = new Board(pieces, totalTurns);
+
+  if (enPassant && enPassant !== '-') {
+    const files = 'abcdefgh';
+    const epX = files.indexOf(enPassant[0]);
+    const epY = parseInt(enPassant[1], 10) - 1;
+    if (epX !== -1 && epY >= 0) {
+      const lastMover = activeColor === 'w' ? TeamType.OPPONENT : TeamType.OUR;
+      const pawnY = epY + (lastMover === TeamType.OUR ? 1 : -1);
+      const pawn = board.pieces.find(p => p.isPawn && p.team === lastMover && p.position.x === epX && p.position.y === pawnY) as Pawn | undefined;
+      if (pawn) pawn.enPassant = true;
+    }
+  }
+
+  board.calculateAllMoves();
+  return board;
+}

--- a/tests/fen-parser.test.ts
+++ b/tests/fen-parser.test.ts
@@ -1,0 +1,31 @@
+import { parseFen } from '@/utils/fen';
+import { PieceType, TeamType } from '@/Types';
+import { Pawn } from '@/models/Pawn';
+
+describe('parseFen', () => {
+  test('parses starting position', () => {
+    const board = parseFen('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1');
+    expect(board.pieces.length).toBe(32);
+    const whiteKing = board.pieces.find(p => p.type === PieceType.KING && p.team === TeamType.OUR)!;
+    expect(whiteKing.hasMoved).toBe(false);
+    const rook = board.pieces.find(p => p.type === PieceType.ROOK && p.team === TeamType.OUR && p.position.x === 7)!;
+    expect(rook.hasMoved).toBe(false);
+    expect(board.totalTurns).toBe(1);
+  });
+
+  test('marks en passant pawn', () => {
+    const board = parseFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1');
+    const pawn = board.pieces.find(p => p.position.x === 4 && p.position.y === 3) as Pawn;
+    expect(pawn).toBeDefined();
+    expect(pawn.enPassant).toBe(true);
+    expect(board.currentTeam).toBe(TeamType.OPPONENT);
+  });
+
+  test('no castling rights sets hasMoved', () => {
+    const board = parseFen('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1');
+    const king = board.pieces.find(p => p.type === PieceType.KING && p.team === TeamType.OUR)!;
+    expect(king.hasMoved).toBe(true);
+    const rook = board.pieces.find(p => p.type === PieceType.ROOK && p.team === TeamType.OUR && p.position.x === 7)!;
+    expect(rook.hasMoved).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `parseFen` to rebuild Board from FEN strings
- mark en-passant and hasMoved flags using FEN data
- use `parseFen` in `Referee.applyState`
- test FEN parsing logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e3baa4688330b86cdc830428e75b