### PR TITLE
Add isServerEnPassant utility

### DIFF
--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -22,6 +22,7 @@ import Chessboard from "../Chessboard/Chessboard";
 import { Howl } from "howler";
 import { sendMove, onMove, onState, onError, requestState } from "@/websocket";
 import { symbolToPieceType } from "@/utils/pieceSymbols";
+import { isServerEnPassant } from "@/utils/serverMove";
 import ChessClock from "../Clock/ChessClock";
 
 import { parseFen } from "@/utils/fen";
@@ -78,17 +79,7 @@ useEffect(() => {
 
       if (piece) {
         const destination = new Position(move.to.x, move.to.y);
-        let enPassant = false;
-        if (
-          piece.isPawn &&
-          Math.abs(move.to.x - move.from.x) === 1 &&
-          move.to.y - move.from.y === (piece.team === TeamType.OUR ? 1 : -1) &&
-          !clonedBoard.pieces.some(
-            (p) => p.position.x === move.to.x && p.position.y === move.to.y
-          )
-        ) {
-          enPassant = true;
-        }
+        const enPassant = isServerEnPassant(move, clonedBoard);
 
         clonedBoard.playMove(enPassant, true, piece, destination);
         if (move.promotion) {

--- a/src/utils/serverMove.ts
+++ b/src/utils/serverMove.ts
@@ -1,0 +1,24 @@
+export interface ServerMove {
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+  promotion?: string;
+}
+
+import { Board } from '@/models/Board';
+import { TeamType } from '@/Types';
+
+export function isServerEnPassant(move: ServerMove, board: Board): boolean {
+  const piece = board.pieces.find(
+    (p) => p.position.x === move.from.x && p.position.y === move.from.y
+  );
+  if (!piece || !piece.isPawn) return false;
+
+  const direction = piece.team === TeamType.OUR ? 1 : -1;
+  const diagonal = Math.abs(move.to.x - move.from.x) === 1;
+  const forward = move.to.y - move.from.y === direction;
+  const targetEmpty = !board.pieces.some(
+    (p) => p.position.x === move.to.x && p.position.y === move.to.y
+  );
+
+  return diagonal && forward && targetEmpty;
+}

--- a/tests/server-moves.test.ts
+++ b/tests/server-moves.test.ts
@@ -2,6 +2,7 @@ import { Board } from '@/models/Board';
 import { Pawn } from '@/models/Pawn';
 import { Piece } from '@/models/Piece';
 import { Position } from '@/models/Position';
+import { isServerEnPassant } from "@/utils/serverMove";
 import { PieceType, TeamType } from '@/Types';
 
 describe('server move application', () => {
@@ -22,13 +23,7 @@ describe('server move application', () => {
     const piece = board.pieces.find(
       (p) => p.position.x === move.from.x && p.position.y === move.from.y
     )!;
-    const enPassant =
-      piece.isPawn &&
-      Math.abs(move.to.x - move.from.x) === 1 &&
-      move.to.y - move.from.y === (piece.team === TeamType.OUR ? 1 : -1) &&
-      !board.pieces.some(
-        (p) => p.position.x === move.to.x && p.position.y === move.to.y
-      );
+    const enPassant = isServerEnPassant(move, board);
 
     board.playMove(enPassant, true, piece, new Position(move.to.x, move.to.y));
 


### PR DESCRIPTION
## Summary
- add `isServerEnPassant` helper in `src/utils/serverMove.ts`
- refactor `applyMove` in Referee to use helper
- use helper in server moves test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853eaa864d483308f4147187592a35c