### PR TITLE
Add FEN-based tests for black special moves

### DIFF
--- a/tests/board-moves.test.ts
+++ b/tests/board-moves.test.ts
@@ -3,6 +3,7 @@ import { Pawn } from '@/models/Pawn';
 import { Piece } from '@/models/Piece';
 import { Position } from '@/models/Position';
 import { PieceType, TeamType } from '@/Types';
+import { parseFen } from '@/utils/fen';
 
 describe('Board move logic', () => {
   test('en passant capture removes the captured pawn', () => {
@@ -55,5 +56,37 @@ describe('Board move logic', () => {
     const whiteKing = board.pieces.find(p => p.isKing && p.team === TeamType.OUR)!;
     const hasCastling = whiteKing.possibleMoves?.some(m => m.x === 6 && m.y === 0);
     expect(hasCastling).toBe(true);
+  });
+
+  test('black can castle kingside from FEN state', () => {
+    const board = parseFen('r3k2r/8/8/8/8/8/8/4K3 b k - 0 1');
+    const blackKing = board.pieces.find(p => p.isKing && p.team === TeamType.OPPONENT)!;
+    const blackRook = board.pieces.find(p => p.isRook && p.team === TeamType.OPPONENT && p.position.x === 7)!;
+
+    const success = board.playMove(false, true, blackKing, new Position(6, 7));
+    expect(success).toBe(true);
+    expect(blackKing.position.x).toBe(6);
+    expect(blackRook.position.x).toBe(5);
+    expect(blackKing.hasMoved).toBe(true);
+    expect(blackRook.hasMoved).toBe(true);
+  });
+
+  test('black en passant capture from FEN removes pawn', () => {
+    const board = parseFen('7k/8/8/8/3pP3/8/8/4K3 b - e3 0 1');
+    const blackPawn = board.pieces.find(p => p.isPawn && p.team === TeamType.OPPONENT)! as Pawn;
+    const success = board.playMove(true, true, blackPawn, new Position(4, 2));
+    expect(success).toBe(true);
+    expect(board.pieces.some(p => p.position.x === 4 && p.position.y === 3)).toBe(false);
+    expect(blackPawn.position.x).toBe(4);
+    expect(blackPawn.position.y).toBe(2);
+  });
+
+  test('black pawn promotion move allowed from FEN', () => {
+    const board = parseFen('7k/8/8/8/8/8/p7/4K3 b - - 0 1');
+    const pawn = board.pieces.find(p => p.isPawn && p.team === TeamType.OPPONENT)! as Pawn;
+    const success = board.playMove(false, true, pawn, new Position(0, 0));
+    expect(success).toBe(true);
+    expect(pawn.position.x).toBe(0);
+    expect(pawn.position.y).toBe(0);
   });
 });

--- a/tests/server-moves.test.ts
+++ b/tests/server-moves.test.ts
@@ -4,6 +4,8 @@ import { Piece } from '@/models/Piece';
 import { Position } from '@/models/Position';
 import { isServerEnPassant } from "@/utils/serverMove";
 import { PieceType, TeamType } from '@/Types';
+import { parseFen } from '@/utils/fen';
+import { symbolToPieceType } from '@/utils/pieceSymbols';
 
 describe('server move application', () => {
   test('en passant capture removes the pawn', () => {
@@ -50,5 +52,46 @@ describe('server move application', () => {
     expect(movedRook.position.x).toBe(5);
     expect(piece.hasMoved).toBe(true);
     expect(movedRook.hasMoved).toBe(true);
+  });
+
+  test('black en passant capture from FEN state', () => {
+    const board = parseFen('7k/8/8/8/3pP3/8/8/4K3 b - e3 0 1');
+    const move = { from: { x: 3, y: 3 }, to: { x: 4, y: 2 } };
+    const piece = board.pieces.find(p => p.position.x === move.from.x && p.position.y === move.from.y)!;
+    const enPassant = isServerEnPassant(move, board);
+    board.playMove(enPassant, true, piece, new Position(move.to.x, move.to.y));
+
+    expect(board.pieces.some(p => p.position.x === 4 && p.position.y === 3)).toBe(false);
+    expect(piece.position.x).toBe(4);
+    expect(piece.position.y).toBe(2);
+  });
+
+  test('black castling from FEN moves king and rook', () => {
+    const board = parseFen('r3k2r/8/8/8/8/8/8/4K3 b k - 0 1');
+    const king = board.pieces.find(p => p.isKing && p.team === TeamType.OPPONENT)!;
+    board.playMove(false, true, king, new Position(6, 7));
+
+    expect(king.position.x).toBe(6);
+    const rook = board.pieces.find(p => p.isRook && p.team === TeamType.OPPONENT && p.position.x === 5)!;
+    expect(rook.position.x).toBe(5);
+    expect(king.hasMoved).toBe(true);
+    expect(rook.hasMoved).toBe(true);
+  });
+
+  test('black pawn promotion applied from server move', () => {
+    const board = parseFen('7k/8/8/8/8/8/p7/4K3 b - - 0 1');
+    const move = { from: { x: 0, y: 1 }, to: { x: 0, y: 0 }, promotion: 'q' };
+    const piece = board.pieces.find(p => p.position.x === move.from.x && p.position.y === move.from.y)!;
+    const enPassant = isServerEnPassant(move, board);
+    board.playMove(enPassant, true, piece, new Position(move.to.x, move.to.y));
+    const promotionType = symbolToPieceType(move.promotion!);
+    board.pieces = board.pieces.map(p =>
+      p.position.x === move.to.x && p.position.y === move.to.y && p.team === piece.team
+        ? new Piece(p.position.clone(), promotionType!, p.team, true)
+        : p
+    );
+
+    const promoted = board.pieces.find(p => p.position.x === 0 && p.position.y === 0 && p.team === TeamType.OPPONENT)!;
+    expect(promoted.type).toBe(PieceType.QUEEN);
   });
 });


### PR DESCRIPTION
## Summary
- cover castling, en-passant and promotion for black pieces
- verify server move handling for these moves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854250ca1688330b2179e4e92157c7c