### PR TITLE
Update Referee modal logic

### DIFF
--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -123,6 +123,14 @@ useEffect(() => {
   };
 }, []);
 
+useEffect(() => {
+  if (board.winningTeam !== undefined) {
+    checkmateModalRef.current?.classList.remove("hidden");
+    stalemateModalRef.current?.classList.add("hidden");
+    checkmateSound.play();
+  }
+}, [board]);
+
 
   function playMove(playedPiece: Piece, destination: Position): boolean {
     // If the playing piece doesn't have any moves return


### PR DESCRIPTION
## Summary
- show checkmate modal when board state signals a winner
- hide stalemate modal at the same time

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685431a14ef08330a9956930b85901dd