### PR TITLE
Handle game over events

### DIFF
--- a/src/components/Clock/ChessClock.tsx
+++ b/src/components/Clock/ChessClock.tsx
@@ -6,6 +6,7 @@ interface ChessClockProps {
   currentTurn: TeamType;
   totalTurns: number;
   onTimeout: (winner: TeamType) => void;
+  gameOver?: boolean;
 }
 
 function parseTimeControl(tc: string): { base: number; inc: number } {
@@ -30,6 +31,7 @@ export default function ChessClock({
   currentTurn,
   totalTurns,
   onTimeout,
+  gameOver: gameOverProp,
 }: ChessClockProps) {
   const { base, inc } = parseTimeControl(timeControl);
   const [whiteTime, setWhiteTime] = useState(base + 5); // 5s bonus for white
@@ -40,6 +42,13 @@ export default function ChessClock({
   );
   const prevTurns = useRef(totalTurns);
   const incRef = useRef(inc);
+
+  // Stop the clock when the parent signals game over
+  useEffect(() => {
+    if (gameOverProp) {
+      setGameOver(true);
+    }
+  }, [gameOverProp]);
 
   useEffect(() => {
     if (gameOver) return;
@@ -71,7 +80,7 @@ export default function ChessClock({
       setBlackTime((t) => (active === 'black' ? Math.max(t - 1, 0) : t));
     }, 1000);
     return () => clearInterval(timer);
-  }, [active]);
+  }, [active, gameOver, totalTurns]);
 
   useEffect(() => {
     if (totalTurns === prevTurns.current) return;

--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -20,7 +20,14 @@ import {
 import { PieceType, TeamType } from "../../Types";
 import Chessboard from "../Chessboard/Chessboard";
 import { Howl } from "howler";
-import { sendMove, onMove, onState, onError, requestState } from "@/websocket";
+import {
+  sendMove,
+  onMove,
+  onState,
+  onError,
+  onGameOver,
+  requestState,
+} from "@/websocket";
 import { symbolToPieceType } from "@/utils/pieceSymbols";
 import { isServerEnPassant } from "@/utils/serverMove";
 import ChessClock from "../Clock/ChessClock";
@@ -56,6 +63,7 @@ export default function Referee({ initialGame, playerColor }: RefereeProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const stalemateModalRef = useRef<HTMLDivElement>(null);
   const checkmateModalRef = useRef<HTMLDivElement>(null);
+  const [gameOver, setGameOver] = useState(false);
   const myTeam: TeamType = playerColor === "white" ? TeamType.OUR : TeamType.OPPONENT;
 
   function handleTimeout(winner: TeamType) {
@@ -64,6 +72,7 @@ export default function Referee({ initialGame, playerColor }: RefereeProps) {
       clone.winningTeam = winner;
       return clone;
     });
+    setGameOver(true);
     checkmateModalRef.current?.classList.remove("hidden");
     checkmateSound.play();
   }
@@ -112,14 +121,31 @@ useEffect(() => {
     alert(msg.message || "An error occurred");
   };
 
+  const handleGameOver = (result: { winner: string | null; reason: string }) => {
+    setBoard((current) => {
+      const clone = current.clone();
+      if (result.reason === "checkmate" && result.winner) {
+        clone.winningTeam = result.winner === "white" ? TeamType.OUR : TeamType.OPPONENT;
+        clone.isStalemate = false;
+      } else {
+        clone.winningTeam = undefined;
+        clone.isStalemate = true;
+      }
+      return clone;
+    });
+    setGameOver(true);
+  };
+
   const unsubMove = onMove(applyMove);
   const unsubState = onState(applyState);
   const unsubError = onError(handleError);
+  const unsubGameOver = onGameOver(handleGameOver);
 
   return () => {
     unsubMove();
     unsubState();
     unsubError();
+    unsubGameOver();
   };
 }, []);
 
@@ -359,6 +385,7 @@ function isStalemate(board: Board, team: TeamType): boolean {
         currentTurn={board.currentTeam}
         totalTurns={board.totalTurns}
         onTimeout={handleTimeout}
+        gameOver={gameOver}
       />
       <div className="modal hidden" ref={modalRef}>
         <div className="modal-body">

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -55,6 +55,17 @@ export function onMove(callback: (move: any) => void): () => void {
   });
 }
 
+// Exported: onGameOver
+export function onGameOver(
+  callback: (result: { winner: string | null; reason: string }) => void
+): () => void {
+  return onMessage((msg) => {
+    if (msg.type === "game-over") {
+      callback(msg.payload);
+    }
+  });
+}
+
 export function onState(callback: (state: any) => void): () => void {
   return onMessage((msg) => {
     if (msg.type === "state") {


### PR DESCRIPTION
## Summary
- expose `onGameOver` from `websocket.ts`
- react to `game-over` events in `Referee`
- allow `ChessClock` to stop when a game finishes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685439ac6bc88330b4f5a9ee24a13d9f