### PR TITLE
Update README with game-over WebSocket info

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ npm test     # run the Jest suite
 
 Running `setup.sh` installs the dependencies automatically.
 
+## `game-over` WebSocket message
+
+When a game concludes the server sends a message of the form:
+
+```json
+{ "type": "game-over", "payload": { "winner": "white" | "black" | null, "reason": "checkmate" | "stalemate" | "draw" } }
+```
+
+The `winner` field is the winning color or `null` for draws. The `reason` can be
+`checkmate`, `stalemate` or `draw` (e.g. repetition or insufficient material).
+Upon receiving this message the client displays a modal indicating whether you
+won, lost or drew the game.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- document the `game-over` WebSocket message
- describe the winner/reason fields
- mention the win/lose/draw modal shown by the client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68543c573070833086cd9561c30775c4