### PR TITLE
Add resign functionality

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -200,6 +200,31 @@ wss.on("connection", (ws) => {
       }
     }
 
+    // Aufgabe eines Spielers
+    if (data.type === "resign") {
+      const game = games[data.gameId];
+      if (game) {
+        if (game.finished) {
+          ws.send(JSON.stringify({ type: "error", message: "Game already finished" }));
+          return;
+        }
+        const resigningColor = playerColors.get(ws);
+        const winner = resigningColor === "white" ? "black" : "white";
+        game.finished = true;
+        game.players.forEach(player => {
+          if (player.readyState === WebSocket.OPEN) {
+            player.send(
+              JSON.stringify({
+                type: "game-over",
+                payload: { winner, reason: "resignation" }
+              })
+            );
+          }
+        });
+      }
+      return;
+    }
+
     // Spielfiguren-Movement
     if (data.type === "move") {
       const game = games[data.gameId];

--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -22,6 +22,7 @@ import Chessboard from "../Chessboard/Chessboard";
 import { Howl } from "howler";
 import {
   sendMove,
+  sendResign,
   onMove,
   onState,
   onError,
@@ -124,7 +125,7 @@ useEffect(() => {
   const handleGameOver = (result: { winner: string | null; reason: string }) => {
     setBoard((current) => {
       const clone = current.clone();
-      if (result.reason === "checkmate" && result.winner) {
+      if ((result.reason === "checkmate" || result.reason === "resignation") && result.winner) {
         clone.winningTeam = result.winner === "white" ? TeamType.OUR : TeamType.OPPONENT;
         clone.isStalemate = false;
       } else {
@@ -375,6 +376,14 @@ function isStalemate(board: Board, team: TeamType): boolean {
     setBoard(initialBoard.clone());
   }
 
+  function handleResign() {
+    if (typeof window === "undefined") return;
+    const confirmed = window.confirm("Aufgeben?");
+    if (confirmed) {
+      sendResign(initialGame.id);
+    }
+  }
+
   return (
     <>
       <p style={{ color: "white", fontSize: "24px", textAlign: "center" }}>
@@ -387,6 +396,7 @@ function isStalemate(board: Board, team: TeamType): boolean {
         onTimeout={handleTimeout}
         gameOver={gameOver}
       />
+      <button onClick={handleResign}>Aufgeben</button>
       <div className="modal hidden" ref={modalRef}>
         <div className="modal-body">
           <img

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -101,6 +101,10 @@ export function sendMove(move: { from: { x: number; y: number }; to: { x: number
   sendMessage({ type: "move", gameId: currentGameId, payload });
 }
 
+export function sendResign(gameId: string) {
+  sendMessage({ type: "resign", gameId });
+}
+
 export function requestState(gameId: string) {
   sendMessage({ type: "state-request", gameId });
 }


### PR DESCRIPTION
## Summary
- add sendResign WebSocket helper
- allow players to resign via button
- process resignation on the server and broadcast game-over
- handle game-over reason `resignation` on the client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556efad11c8330ae30b4785bcdef12