### PR TITLE
Add back button in waiting room

### DIFF
--- a/app/waiting-room/[id]/page.tsx
+++ b/app/waiting-room/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { connectToGame, onMessage } from "@/websocket";
+import Link from "next/link";
 
 export default function WaitingRoom() {
   const params = useParams();
@@ -30,8 +31,14 @@ export default function WaitingRoom() {
   }, [id, router]);
 
   return (
-    <div className="min-h-screen bg-blue-900 text-white flex items-center justify-center">
+    <div className="min-h-screen bg-blue-900 text-white flex flex-col items-center justify-center space-y-4">
       <p>Warte auf Gegner…</p>
+      <Link
+        href="/"
+        className="px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded text-white font-semibold"
+      >
+        Zurück
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add link to return to main menu on the waiting room page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856c0c037388330b5013a883ed7e306