### PR TITLE
Implement draw offer mechanic

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -240,6 +240,46 @@ wss.on("connection", (ws) => {
       return;
     }
 
+    // Draw offer from a player
+    if (data.type === "offer-draw") {
+      const game = games[data.gameId];
+      if (game && !game.finished) {
+        game.players.forEach(player => {
+          if (player !== ws && player.readyState === WebSocket.OPEN) {
+            player.send(JSON.stringify({ type: "draw-offer" }));
+          }
+        });
+      }
+      return;
+    }
+
+    // Response to a draw offer
+    if (data.type === "respond-draw") {
+      const game = games[data.gameId];
+      if (game && !game.finished) {
+        if (data.accept) {
+          game.finished = true;
+          game.players.forEach(player => {
+            if (player.readyState === WebSocket.OPEN) {
+              player.send(
+                JSON.stringify({
+                  type: "game-over",
+                  payload: { winner: null, reason: "draw" }
+                })
+              );
+            }
+          });
+        } else {
+          game.players.forEach(player => {
+            if (player !== ws && player.readyState === WebSocket.OPEN) {
+              player.send(JSON.stringify({ type: "draw-declined" }));
+            }
+          });
+        }
+      }
+      return;
+    }
+
     // Spielfiguren-Movement
     if (data.type === "move") {
       const game = games[data.gameId];

--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -23,11 +23,15 @@ import { Howl } from "howler";
 import {
   sendMove,
   sendResign,
+  sendOfferDraw,
+  respondDraw,
   onMove,
   onState,
   onError,
   onGameOver,
   requestState,
+  onDrawOffer,
+  onDrawDeclined,
 } from "@/websocket";
 import { symbolToPieceType } from "@/utils/pieceSymbols";
 import { isServerEnPassant } from "@/utils/serverMove";
@@ -141,12 +145,23 @@ useEffect(() => {
   const unsubState = onState(applyState);
   const unsubError = onError(handleError);
   const unsubGameOver = onGameOver(handleGameOver);
+  const unsubDrawOffer = onDrawOffer(() => {
+    if (typeof window === "undefined") return;
+    const accept = window.confirm("Do you want to accept a draw?");
+    respondDraw(initialGame.id, accept);
+  });
+  const unsubDrawDeclined = onDrawDeclined(() => {
+    if (typeof window === "undefined") return;
+    alert("Draw offer declined");
+  });
 
   return () => {
     unsubMove();
     unsubState();
     unsubError();
     unsubGameOver();
+    unsubDrawOffer();
+    unsubDrawDeclined();
   };
 }, []);
 
@@ -384,6 +399,14 @@ function isStalemate(board: Board, team: TeamType): boolean {
     }
   }
 
+  function handleOfferDraw() {
+    if (typeof window === "undefined") return;
+    const confirmed = window.confirm("Do you want to offer a draw?");
+    if (confirmed) {
+      sendOfferDraw(initialGame.id);
+    }
+  }
+
   return (
     <>
       <p style={{ color: "white", fontSize: "24px", textAlign: "center" }}>
@@ -397,6 +420,7 @@ function isStalemate(board: Board, team: TeamType): boolean {
         gameOver={gameOver}
       />
       <button onClick={handleResign}>Aufgeben</button>
+      <button onClick={handleOfferDraw}>Offer draw</button>
       <div className="modal hidden" ref={modalRef}>
         <div className="modal-body">
           <img

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -105,6 +105,14 @@ export function sendResign(gameId: string) {
   sendMessage({ type: "resign", gameId });
 }
 
+export function sendOfferDraw(gameId: string) {
+  sendMessage({ type: "offer-draw", gameId });
+}
+
+export function respondDraw(gameId: string, accept: boolean) {
+  sendMessage({ type: "respond-draw", gameId, accept });
+}
+
 export function requestState(gameId: string) {
   sendMessage({ type: "state-request", gameId });
 }
@@ -117,6 +125,22 @@ export function onGamesList(callback: (games: any[]) => void): () => void {
   return onMessage(msg => {
     if (msg.type === "games-list") {
       callback(msg.games);
+    }
+  });
+}
+
+export function onDrawOffer(callback: () => void): () => void {
+  return onMessage(msg => {
+    if (msg.type === "draw-offer") {
+      callback();
+    }
+  });
+}
+
+export function onDrawDeclined(callback: () => void): () => void {
+  return onMessage(msg => {
+    if (msg.type === "draw-declined") {
+      callback();
     }
   });
 }


### PR DESCRIPTION
## Summary
- add draw offer endpoints in the websocket server
- expose offer/response functions in the websocket client
- handle draw offers in `Referee` and add "Offer draw" button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856c312282c83309434a51a89ff8ff3