### PR TITLE
Add WebSocket games list

### DIFF
--- a/app/waiting-games/page.tsx
+++ b/app/waiting-games/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
-import { connectSocket, onMessage } from "@/websocket";
+import { connectSocket, onMessage, requestGames } from "@/websocket";
 import Link from "next/link";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 
 type WaitingGame = { id: string; timeControl: string; stake: number; };
 
@@ -11,15 +9,14 @@ export default function WaitingGamesPage() {
   const [games, setGames] = useState<WaitingGame[]>([]);
 
   useEffect(() => {
-    // Initiale Liste via HTTP
-    fetch(`${API_URL}/games`)
-      .then(res => res.json())
-      .then((data: WaitingGame[]) => setGames(data))
-      .catch(console.error);
+    connectSocket();
+    requestGames();
 
     // WebSocket-Updates
-    connectSocket();
     const off = onMessage((msg) => {
+      if (msg.type === "games-list") {
+        setGames(msg.games as WaitingGame[]);
+      }
       if (msg.type === "new-game") {
         setGames(prev => [...prev, msg.payload]);
       }

--- a/server.ts
+++ b/server.ts
@@ -69,7 +69,9 @@ app.get("/games", (req: Request, res: Response, next: NextFunction) => {
     "GET /games → Spieler pro Spiel:",
     Object.values(games).map(g => ({ id: g.id, playersCount: g.players.length }))
   );
-  const openGames = Object.values(games).filter(g => g.players.length < 2);
+  const openGames = Object.values(games).filter(
+    g => !g.started && g.players.length < 2
+  );
   res.json(openGames);
 });
 
@@ -129,6 +131,15 @@ wss.on("connection", (ws) => {
       } else {
         ws.send(JSON.stringify({ type: "error", message: "Spiel nicht gefunden" }));
       }
+      return;
+    }
+
+    // Aktuelle Liste offener Spiele anfordern
+    if (data.type === "games-request") {
+      const openGames = Object.values(games)
+        .filter(g => !g.started && g.players.length < 2)
+        .map(g => ({ id: g.id, timeControl: g.timeControl, stake: g.stake }));
+      ws.send(JSON.stringify({ type: "games-list", games: openGames }));
       return;
     }
 

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -109,3 +109,15 @@ export function requestState(gameId: string) {
   sendMessage({ type: "state-request", gameId });
 }
 
+export function requestGames() {
+  sendMessage({ type: "games-request" });
+}
+
+export function onGamesList(callback: (games: any[]) => void): () => void {
+  return onMessage(msg => {
+    if (msg.type === "games-list") {
+      callback(msg.games);
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- allow requesting open games via `games-request`/`games-list` WebSocket messages
- expose helpers `requestGames` and `onGamesList` to the client
- update waiting games page to load list via WebSocket instead of HTTP
- filter out games that have already started so they never reappear in the waiting list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855b94478ec833082c0e5ac86af0662