### PR TITLE
Add payout on game over

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -90,6 +90,11 @@ export default function GamePage() {
         if (!MiniKit.isInstalled()) continue;
 
         const { finalPayload } = await MiniKit.commandsAsync.pay(payload);
+        if (finalPayload.from) {
+          try {
+            localStorage.setItem("userAddress", finalPayload.from);
+          } catch {}
+        }
 
         await fetch('/api/confirm-payment', {
           method: 'POST',

--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -38,6 +38,7 @@ import { isServerEnPassant } from "@/utils/serverMove";
 import ChessClock from "../Clock/ChessClock";
 
 import { parseFen } from "@/utils/fen";
+import { MiniKit, tokenToDecimals, Tokens, PayCommandInput } from "@worldcoin/minikit-js";
 
 interface RefereeProps {
   initialGame: {
@@ -120,6 +121,44 @@ useEffect(() => {
     setBoard(() => parseFen(state.fen));
   };
 
+  const distributeWinnings = async (winner: string | null) => {
+    if (typeof window === "undefined") return;
+    const address = localStorage.getItem("userAddress");
+    if (!address) return;
+
+    const res = await fetch('/api/initiate-pay', { method: 'POST' });
+    const { id: reference } = await res.json();
+
+    let amount = initialGame.stake * 0.95;
+    if (winner && winner === playerColor) {
+      amount = initialGame.stake * 2 * 0.95;
+    } else if (winner) {
+      return; // loser sends nothing
+    }
+
+    const payload: PayCommandInput = {
+      reference,
+      to: address,
+      tokens: [
+        {
+          symbol: Tokens.WLD,
+          token_amount: tokenToDecimals(amount, Tokens.WLD).toString(),
+        },
+      ],
+      description: `Payout for game ${initialGame.id}`,
+    };
+
+    if (!MiniKit.isInstalled()) return;
+
+    const { finalPayload } = await MiniKit.commandsAsync.pay(payload);
+
+    await fetch('/api/confirm-payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(finalPayload),
+    });
+  };
+
   const handleError = (msg: any) => {
     // Refresh the board state in case we desynced
     requestState(initialGame.id);
@@ -139,6 +178,7 @@ useEffect(() => {
       return clone;
     });
     setGameOver(true);
+    distributeWinnings(result.winner);
   };
 
   const unsubMove = onMove(applyMove);


### PR DESCRIPTION
## Summary
- store user address when paying stake
- pay out winnings via minikit when the game ends

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856fda9e1b48330a8e656b030cbf6bb