### PR TITLE
Add finishGame after payments

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { connectSocket, connectToGame, onMessage, requestState } from "@/websocket";
 import App from "../../../src/App";
 import { MiniKit, tokenToDecimals, Tokens, PayCommandInput } from "@worldcoin/minikit-js";
@@ -17,10 +17,20 @@ interface Game {
 
 export default function GamePage() {
   const { id } = useParams();
+  const router = useRouter();
   const [game, setGame] = useState<{ id: string; timeControl: string; stake: number; started: boolean; } | null>(null);
   const [playerColor, setPlayerColor] = useState<"white" | "black" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const paidRef = useRef(false);
+
+  const finishGame = () => {
+    setGame(null);
+    setPlayerColor(null);
+    try {
+      localStorage.removeItem("worldchess-color");
+    } catch {}
+    router.push("/");
+  };
 
   useEffect(() => {
     const stored = localStorage.getItem("worldchess-color");
@@ -111,6 +121,6 @@ export default function GamePage() {
   if (!game) return <p>Spiel wird geladen…</p>;
   if (!game.started || !playerColor) return <p>Warte auf Gegner…</p>;
 
-  return <App initialGame={game} playerColor={playerColor} />;
+  return <App initialGame={game} playerColor={playerColor} finishGame={finishGame} />;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,15 +9,16 @@ interface AppProps {
     started: boolean;
   };
   playerColor: 'white' | 'black';
+  finishGame: () => void;
 }
 
 
 
-export default function App({ initialGame, playerColor }: AppProps) {
+export default function App({ initialGame, playerColor, finishGame }: AppProps) {
   return (
     <div id="app">
       {/* Pass both game data and playerColor to your Referee */}
-      <Referee initialGame={initialGame} playerColor={playerColor} />
+      <Referee initialGame={initialGame} playerColor={playerColor} finishGame={finishGame} />
     </div>
   );
 }

--- a/src/components/Referee/Referee.tsx
+++ b/src/components/Referee/Referee.tsx
@@ -48,6 +48,7 @@ interface RefereeProps {
     started: boolean;
   };
   playerColor: 'white' | 'black';
+  finishGame: () => void;
 }
 
 const moveSound = new Howl({
@@ -62,7 +63,7 @@ const checkmateSound = new Howl({
   src: ["/sounds/move-check.mp3"],
 });
 
-export default function Referee({ initialGame, playerColor }: RefereeProps) {
+export default function Referee({ initialGame, playerColor, finishGame }: RefereeProps) {
   const [board, setBoard] = useState<Board>(initialBoard.clone());
   const [promotionPawn, setPromotionPawn] = useState<Piece>();
   const [pendingPromotion, setPendingPromotion] = useState<{ from: Position; to: Position } | null>(null);
@@ -178,7 +179,7 @@ useEffect(() => {
       return clone;
     });
     setGameOver(true);
-    distributeWinnings(result.winner);
+    distributeWinnings(result.winner).finally(() => finishGame());
   };
 
   const unsubMove = onMove(applyMove);


### PR DESCRIPTION
## Summary
- route users back to home once payouts are handled
- pass finishGame callback through App and Referee
- trigger finishGame after confirmation of `game-over`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685708e3320c83308c83f028bf381a69