### PR TITLE
Unify servers on single port

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_API_URL=http://localhost:3001
-NEXT_PUBLIC_WS_URL=ws://localhost:8080
+NEXT_PUBLIC_API_URL=http://localhost:3000
+NEXT_PUBLIC_WS_URL=ws://localhost:3000

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ cp .env.local.example .env.local
 The file defines the following variables used by the client:
 
 ```env
-NEXT_PUBLIC_API_URL=http://localhost:3001
-NEXT_PUBLIC_WS_URL=ws://localhost:8080
+NEXT_PUBLIC_API_URL=http://localhost:3000
+NEXT_PUBLIC_WS_URL=ws://localhost:3000
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -6,7 +6,7 @@ import App from "../../../src/App";
 import { MiniKit, tokenToDecimals, Tokens, PayCommandInput } from "@worldcoin/minikit-js";
 import { useRef } from "react";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
 
 interface Game {
   id: string;

--- a/combined.txt
+++ b/combined.txt
@@ -785,7 +785,7 @@ export default function GamePage() {
   useEffect(() => {
     connectSocket();
     // HTTP-Fallback
-    fetch(`http://localhost:3001/games/${id}`)
+    fetch(`http://localhost:3000/games/${id}`)
       .then(res => {
         if (!res.ok) throw new Error("Spiel nicht gefunden");
         return res.json();

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "ts-node server.ts",
     "build": "next build",
-    "start": "next start",
+    "start": "NODE_ENV=production ts-node server.ts",
     "lint": "next lint",
     "test": "jest"
   },

--- a/server.ts
+++ b/server.ts
@@ -4,10 +4,13 @@ import { WebSocketServer, WebSocket } from "ws";
 import { Chess } from "chess.js";
 import fs from "fs";
 import path from "path";
+import http from "http";
+import next from "next";
 
-const app = express();
-const HTTP_PORT = 3001;
-const WS_PORT = 8080;
+const PORT = parseInt(process.env.PORT || "3000", 10);
+const dev = process.env.NODE_ENV !== "production";
+const nextApp = next({ dev });
+const handle = nextApp.getRequestHandler();
 
 // Set up logging
 const LOG_DIR = path.join(__dirname, "logs");
@@ -47,8 +50,10 @@ function logGameResult(
   });
 }
 
-app.use(cors());
-app.use(express.json());
+nextApp.prepare().then(() => {
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
 
 // In-Memory Speicher für offene Spiele
 interface Game {
@@ -115,16 +120,18 @@ app.get("/games/:id", (req: Request, res: Response, next: NextFunction) => {
   });
 });
 
-// HTTP-Server starten
-app.listen(HTTP_PORT, () => {
-  console.log(`HTTP Server läuft auf http://localhost:${HTTP_PORT}`);
-});
+  // Create HTTP and WebSocket servers on the same port
+  const server = http.createServer(app);
+  const wss = new WebSocketServer({ server });
 
-// WebSocket-Server
-const wss = new WebSocketServer({ port: WS_PORT });
-console.log(`WebSocket Server läuft auf ws://localhost:${WS_PORT}`);
+  server.listen(PORT, () => {
+    console.log(`Server läuft auf http://localhost:${PORT}`);
+  });
+  console.log(`WebSocket Server läuft auf ws://localhost:${PORT}`);
 
-wss.on("connection", (ws) => {
+  app.all("*", (req, res) => handle(req, res));
+
+  wss.on("connection", (ws) => {
   console.log("WebSocket: Ein Client verbunden");
 
   ws.on("message", (message) => {
@@ -430,5 +437,7 @@ wss.on("connection", (ws) => {
       }
     }
   });
+});
+
 });
 

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -1,6 +1,6 @@
 let socket: WebSocket | null = null;
 let currentGameId: string | null = null;
-const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8080";
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:3000";
 
 export function connectSocket() {
   if (!socket || socket.readyState === WebSocket.CLOSED) {


### PR DESCRIPTION
## Summary
- consolidate Express, WebSocket and Next.js into one server
- update defaults to use port 3000 everywhere
- adjust example env file and README
- run server with ts-node via updated scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b99a376508330b1b71e8a7dea368b