### PR TITLE
Add World ID verify integration

### DIFF
--- a/app/api/verify/route.ts
+++ b/app/api/verify/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyCloudProof, IVerifyResponse, ISuccessResult } from '@worldcoin/minikit-js'
+
+interface IRequestPayload {
+  payload: ISuccessResult
+  action: string
+  signal: string | undefined
+}
+
+export async function POST(req: NextRequest) {
+  const { payload, action, signal } = (await req.json()) as IRequestPayload
+  const app_id = process.env.APP_ID as `app_${string}`
+  const verifyRes = (await verifyCloudProof(payload, app_id, action, signal)) as IVerifyResponse
+
+  if (verifyRes.success) {
+    // This is where you should perform backend actions if the verification succeeds
+    // Such as, setting a user as "verified" in a database
+    return NextResponse.json({ verifyRes, status: 200 })
+  } else {
+    // This is where you should handle errors from the World ID /verify endpoint.
+    // Usually these errors are due to a user having already verified.
+    return NextResponse.json({ verifyRes, status: 400 })
+  }
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
-import './globals.css';
-import type { ReactNode } from 'react';
+import './globals.css'
+import type { ReactNode } from 'react'
+import { MiniKitProvider } from '@/components/MiniKitProvider'
 
 export const metadata = {
   title: 'Next.js',
@@ -14,7 +15,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="bg-blue-900 text-white min-h-screen">
-        {children}
+        <MiniKitProvider>{children}</MiniKitProvider>
       </body>
     </html>
   );

--- a/src/components/MiniKitProvider.tsx
+++ b/src/components/MiniKitProvider.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, ReactNode } from 'react'
+import { MiniKit, VerifyCommandInput, VerificationLevel, ISuccessResult } from '@worldcoin/minikit-js'
+
+export const MiniKitProvider = ({ children }: { children: ReactNode }) => {
+  useEffect(() => {
+    MiniKit.install()
+
+    const verifyPayload: VerifyCommandInput = {
+      action: 'voting-action',
+      signal: '0x12312',
+      verification_level: VerificationLevel.Orb,
+    }
+
+    const handleVerify = async () => {
+      if (!MiniKit.isInstalled()) {
+        return
+      }
+      const { finalPayload } = await MiniKit.commandsAsync.verify(verifyPayload)
+      if ((finalPayload as any).status === 'error') {
+        return console.log('Error payload', finalPayload)
+      }
+
+      const verifyResponse = await fetch('/api/verify', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          payload: finalPayload as ISuccessResult,
+          action: verifyPayload.action,
+          signal: verifyPayload.signal,
+        }),
+      })
+      const verifyResponseJson = await verifyResponse.json()
+      if (verifyResponseJson.status === 200) {
+        console.log('Verification success!')
+      }
+    }
+
+    handleVerify()
+  }, [])
+
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- integrate World ID verification backend route
- verify user on app load using MiniKit

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf97a32288330990600feadc59e3b