### PR TITLE
Fix websocket server path

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_API_URL=http://localhost:3000
-NEXT_PUBLIC_WS_URL=ws://localhost:3000
+NEXT_PUBLIC_WS_URL=ws://localhost:3000/ws

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The file defines the following variables used by the client:
 
 ```env
 NEXT_PUBLIC_API_URL=http://localhost:3000
-NEXT_PUBLIC_WS_URL=ws://localhost:3000
+NEXT_PUBLIC_WS_URL=ws://localhost:3000/ws
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/server.ts
+++ b/server.ts
@@ -122,7 +122,19 @@ app.get("/games/:id", (req: Request, res: Response, next: NextFunction) => {
 
   // Create HTTP and WebSocket servers on the same port
   const server = http.createServer(app);
-  const wss = new WebSocketServer({ server });
+  const wss = new WebSocketServer({ noServer: true });
+  const upgrade = nextApp.getUpgradeHandler();
+
+  server.on('upgrade', (req, socket, head) => {
+    const { pathname } = new URL(req.url || '', `http://${req.headers.host}`);
+    if (pathname === '/ws') {
+      wss.handleUpgrade(req, socket, head, ws => {
+        wss.emit('connection', ws, req);
+      });
+    } else {
+      upgrade(req, socket, head);
+    }
+  });
 
   server.listen(PORT, () => {
     console.log(`Server läuft auf http://localhost:${PORT}`);

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -1,6 +1,6 @@
 let socket: WebSocket | null = null;
 let currentGameId: string | null = null;
-const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:3000";
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:3000/ws";
 
 export function connectSocket() {
   if (!socket || socket.readyState === WebSocket.CLOSED) {


### PR DESCRIPTION
## Summary
- handle Next.js and custom websockets on same port
- default websocket endpoint to `/ws`
- update README and example env file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685edce5fc108330a7e25cbed378d577