### PR TITLE
Improve dev resilience for verification & WebSocket URL

### DIFF
--- a/src/components/MiniKitProvider.tsx
+++ b/src/components/MiniKitProvider.tsx
@@ -33,8 +33,25 @@ export const MiniKitProvider = ({ children }: { children: ReactNode }) => {
           signal: verifyPayload.signal,
         }),
       })
-      const verifyResponseJson = await verifyResponse.json()
-      if (verifyResponseJson.status === 200) {
+
+      // The API can fail in development which results in an empty body. Guard
+      // against JSON parsing errors to avoid crashing the client.
+      let verifyResponseJson: any = null
+      const contentType = verifyResponse.headers.get('content-type') || ''
+      if (contentType.includes('application/json')) {
+        try {
+          verifyResponseJson = await verifyResponse.json()
+        } catch (err) {
+          console.error('Failed to parse verification response', err)
+        }
+      } else {
+        console.error(
+          'Verification endpoint did not return JSON:',
+          await verifyResponse.text()
+        )
+      }
+
+      if (verifyResponseJson?.status === 200) {
         console.log('Verification success!')
       }
     }

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -1,10 +1,20 @@
 let socket: WebSocket | null = null;
 let currentGameId: string | null = null;
-const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:3000/ws";
+
+function getWebSocketUrl() {
+  if (process.env.NEXT_PUBLIC_WS_URL) {
+    return process.env.NEXT_PUBLIC_WS_URL;
+  }
+  if (typeof window !== "undefined") {
+    const proto = window.location.protocol === "https:" ? "wss" : "ws";
+    return `${proto}://${window.location.host}/ws`;
+  }
+  return "ws://localhost:3000/ws";
+}
 
 export function connectSocket() {
   if (!socket || socket.readyState === WebSocket.CLOSED) {
-    socket = new WebSocket(WS_URL);
+    socket = new WebSocket(getWebSocketUrl());
     console.log("Connecting to WebSocket...");
     socket.onopen = () => {
       console.log("[WebSocket] verbunden");


### PR DESCRIPTION
## Summary
- guard against failing `/api/verify` responses
- build WebSocket URL dynamically to support HTTPS pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee279e2dc83309ddbbe00b7bc121e