### PR TITLE
Change payment timing

### DIFF
--- a/app/create-game/page.tsx
+++ b/app/create-game/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { connectSocket, sendMessage, onMessage } from "@/websocket";
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { MiniKit, tokenToDecimals, Tokens, PayCommandInput } from "@worldcoin/minikit-js";
 
 export default function CreateGamePage() {
   const [timeControl, setTimeControl] = useState("15+10");
@@ -24,7 +25,7 @@ export default function CreateGamePage() {
          };
   }, [router]);
 
-  const handleCreate = () => {
+  const handleCreate = async () => {
     const newGame = {
       id: crypto.randomUUID(),
       timeControl,
@@ -36,6 +37,45 @@ export default function CreateGamePage() {
     // optional: localStorage
     const existing = JSON.parse(localStorage.getItem("waitingGames") || "[]");
     localStorage.setItem("waitingGames", JSON.stringify([...existing, newGame]));
+
+    const payStake = async () => {
+      const key = `stakePaid-${newGame.id}`;
+      if (typeof window === "undefined" || localStorage.getItem(key)) return;
+      for (let i = 0; i < 2; i++) {
+        const res = await fetch('/api/initiate-pay', { method: 'POST' });
+        const { id: reference } = await res.json();
+
+        const payload: PayCommandInput = {
+          reference,
+          to: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+          tokens: [
+            {
+              symbol: Tokens.WLD,
+              token_amount: tokenToDecimals(newGame.stake, Tokens.WLD).toString(),
+            },
+          ],
+          description: `Stake payment for game ${newGame.id}`,
+        };
+
+        if (!MiniKit.isInstalled()) continue;
+
+        const { finalPayload } = await MiniKit.commandsAsync.pay(payload);
+        if (finalPayload.from) {
+          try {
+            localStorage.setItem("userAddress", finalPayload.from);
+          } catch {}
+        }
+
+        await fetch('/api/confirm-payment', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(finalPayload),
+        });
+      }
+      localStorage.setItem(key, 'true');
+    };
+
+    await payStake();
 
     // A2) WS‑Nachricht senden
     console.log("[create-game] sende WS new-game");

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -79,6 +79,8 @@ export default function GamePage() {
   useEffect(() => {
     const payStake = async () => {
       if (!game || paidRef.current || game.stake === 0) return;
+      const key = `stakePaid-${game.id}`;
+      if (typeof window !== "undefined" && localStorage.getItem(key)) return;
       paidRef.current = true;
 
       for (let i = 0; i < 2; i++) {
@@ -111,6 +113,9 @@ export default function GamePage() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(finalPayload),
         });
+      }
+      if (typeof window !== "undefined") {
+        localStorage.setItem(key, 'true');
       }
     };
 


### PR DESCRIPTION
## Summary
- request a deposit via Worldcoin MiniKit when creating a game
- avoid double-charging in game page by persisting a `stakePaid` flag in localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef536a2c883309c733750bb18cd4e