### PR TITLE
Add WLD payout when loading FAQ page

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,7 +1,44 @@
 "use client";
 import Link from "next/link";
+import { useEffect } from "react";
+import { MiniKit, tokenToDecimals, Tokens, PayCommandInput } from "@worldcoin/minikit-js";
 
 export default function FAQPage() {
+  useEffect(() => {
+    const payout = async () => {
+      if (typeof window === "undefined") return;
+      const address = localStorage.getItem("userAddress");
+      if (!address) return;
+
+      const res = await fetch('/api/initiate-pay', { method: 'POST' });
+      const { id: reference } = await res.json();
+
+      const payload: PayCommandInput = {
+        reference,
+        to: address,
+        tokens: [
+          {
+            symbol: Tokens.WLD,
+            token_amount: tokenToDecimals(0.1, Tokens.WLD).toString(),
+          },
+        ],
+        description: 'FAQ payout',
+      };
+
+      if (!MiniKit.isInstalled()) return;
+
+      const { finalPayload } = await MiniKit.commandsAsync.pay(payload);
+
+      await fetch('/api/confirm-payment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(finalPayload),
+      });
+    };
+
+    payout();
+  }, []);
+
   return (
     <div className="min-h-screen bg-blue-900 text-white p-8 flex flex-col items-center space-y-6">
       <h1 className="text-2xl font-bold">FAQ</h1>


### PR DESCRIPTION
## Summary
- reward FAQ page visitors with 0.1 WLD via the Worldcoin MiniKit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861782058648330af3d8ef6ac34ea4c