### PR TITLE
Use OnePay quick action for FAQ payout

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useEffect } from "react";
-import { MiniKit, tokenToDecimals, Tokens, PayCommandInput } from "@worldcoin/minikit-js";
+
 
 export default function FAQPage() {
   useEffect(() => {
@@ -12,36 +12,17 @@ export default function FAQPage() {
       if (!address || localStorage.getItem(doneKey)) return;
 
       const res = await fetch('/api/initiate-pay', { method: 'POST' });
-      const { id: reference } = await res.json();
+      const { id: paymentId } = await res.json();
 
-      const payload: PayCommandInput = {
-        reference,
-        to: address,
-        tokens: [
-          {
-            symbol: Tokens.WLD,
-            token_amount: tokenToDecimals(0.1, Tokens.WLD).toString(),
-          },
-        ],
-        description: 'FAQ payout',
-      };
-
-      if (!MiniKit.isInstalled()) return;
-
-      const { finalPayload } = await MiniKit.commandsAsync.pay(payload);
-      if ('from' in finalPayload && finalPayload.from) {
-        try {
-          localStorage.setItem("userAddress", finalPayload.from);
-        } catch {}
-      }
-
-      await fetch('/api/confirm-payment', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(finalPayload),
-      });
+      const url = new URL('https://worldcoin.org/mini-app');
+      url.searchParams.set('app_id', 'app_d9589ab005e18dcf362d2ea26aef669e');
+      url.searchParams.set('path', '/pay');
+      url.searchParams.set('paymentId', paymentId);
+      url.searchParams.set('recipient', address);
+      url.searchParams.set('amount', '0.1');
 
       localStorage.setItem(doneKey, 'true');
+      window.location.href = url.toString();
     };
 
     payout();


### PR DESCRIPTION
## Summary
- replace MiniKit `pay` command on FAQ page with a direct OnePay quick action link

## Testing
- `npm test`
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686236b580d08330956e4e11dfee8d41