### PR TITLE
Add payout test button

### DIFF
--- a/app/WLD_ABI.json
+++ b/app/WLD_ABI.json
@@ -1,0 +1,12 @@
+[
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_to", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "type": "function"
+  }
+]

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,46 +1,67 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { MiniKit } from "@worldcoin/minikit-js"
+import WLD_ABI from "../WLD_ABI.json"
 
+const WLD_TOKEN_ADDRESS = "0x4C34d508C19562f5020b7b6209aA3Ac1E0188c10"
+
+async function payoutUser(address: string) {
+  try {
+    const { finalPayload } = await MiniKit.commandsAsync.sendTransaction({
+      transaction: [
+        {
+          address: WLD_TOKEN_ADDRESS,
+          abi: WLD_ABI as any,
+          functionName: "transfer",
+          args: [address, "100000000000000000"],
+        },
+      ],
+    })
+
+    console.log("Transaktionstatus:", (finalPayload as any).status)
+  } catch (error) {
+    console.error("Auszahlung fehlgeschlagen", error)
+  }
+}
 
 export default function FAQPage() {
+  const [userAddress, setUserAddress] = useState<string | null>(null)
+  const [loadingAddress, setLoadingAddress] = useState(true)
+
   useEffect(() => {
-    const sendOnePay = async () => {
+    const fetchAddress = async () => {
       try {
-        const reference = `faq-test-${Date.now()}`
-
-        await MiniKit.commandsAsync.pay({
-          reference,
-          to: "app_wallet", // App-Wallet-Adresse wird automatisch erkannt
-          tokens: [
-            {
-              symbol: "WLD",
-              token_amount: "100000000000000000", // 0.1 WLD in wei
-            },
-          ],
-          domain: {
-            chainId: 10,
-            name: "worldcoin",
-            version: "1",
-          },
-          description: "FAQ Testzahlung – 0.1 WLD",
-        })
-
-        console.log("Zahlung erfolgreich ausgelöst")
-      } catch (error) {
-        console.error("Zahlung fehlgeschlagen", error)
+        const info = await MiniKit.getUserInfo()
+        if (info.walletAddress) {
+          setUserAddress(info.walletAddress)
+        }
+      } catch (err) {
+        console.error("Nutzerinfo konnte nicht geladen werden", err)
+      } finally {
+        setLoadingAddress(false)
       }
     }
 
-    sendOnePay()
+    fetchAddress()
   }, [])
 
   return (
     <main className="p-6 text-white">
       <h1 className="text-2xl font-bold mb-4">FAQ</h1>
-      <p>Diese Seite löst beim Öffnen automatisch eine Testzahlung aus (0.1 WLD).</p>
+      {loadingAddress ? (
+        <p>Lade Nutzeradresse...</p>
+      ) : userAddress ? (
+        <button
+          onClick={() => payoutUser(userAddress)}
+          className="mb-4 px-6 py-3 bg-green-600 hover:bg-green-700 rounded text-white font-semibold"
+        >
+          0.1 WLD Test-Auszahlung starten
+        </button>
+      ) : (
+        <p>Bitte einloggen oder verifizieren.</p>
+      )}
       <Link
         href="/"
         className="mt-8 px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded text-white font-semibold"


### PR DESCRIPTION
## Summary
- add `WLD_ABI.json` for WLD token transfer
- replace FAQ page payment with payout button using `sendTransaction`

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6863a063f0388330bb0606c707f7cc5d