### PR TITLE
Restore verification flow

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -35,10 +35,7 @@ export default function FAQPage() {
     const fetchAddress = async () => {
       try {
 
-        if (
-          typeof window !== 'undefined' &&
-          localStorage.getItem('worldIdVerified') === 'true'
-        ) {
+        if (typeof window !== 'undefined' && localStorage.getItem('worldIdVerified') === 'true') {
           setIsVerified(true)
         }
 

--- a/src/components/MiniKitProvider.tsx
+++ b/src/components/MiniKitProvider.tsx
@@ -6,11 +6,11 @@ import { MiniKit, VerifyCommandInput, VerificationLevel, ISuccessResult } from '
 let verificationStarted = false
 
 export const MiniKitProvider = ({ children }: { children: ReactNode }) => {
-  const initializedRef = useRef(false)
-
+  const hasRunRef = useRef(false)
   useEffect(() => {
-    if (initializedRef.current) return
-    initializedRef.current = true
+
+    if (verificationStarted) return
+    verificationStarted = true
 
     MiniKit.install()
 
@@ -47,8 +47,7 @@ export const MiniKitProvider = ({ children }: { children: ReactNode }) => {
         }),
       })
 
-      const resJson = await verifyResponse.json().catch(() => ({} as any))
-
+      const resJson = await verifyResponse.json().catch(() => ({}))
 
       if (verifyResponse.ok || resJson.code === 'max_verifications_reached') {
         console.log('Verification success!')


### PR DESCRIPTION
## Summary
- revert auth flow regression by restoring the previous `MiniKitProvider`
- ensure verification and wallet auth dialogs display again

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868ee86604c8330ac8254581b9e1fed