### PR TITLE
Add reset verification button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,6 +31,17 @@ export default function Page() {
         >
           Wartende Spiele
         </Link>
+        <button
+          onClick={() => {
+            if (typeof window !== 'undefined') {
+              localStorage.clear()
+              location.reload()
+            }
+          }}
+          className="block w-64 bg-red-600 hover:bg-red-700 text-white text-lg font-semibold py-3 px-6 rounded-lg text-center shadow-md hover:shadow-lg border border-red-400"
+        >
+          Verifizierung zurücksetzen
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a new button on the homepage to clear localStorage and reload the page

## Testing
- `npm test`
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686925de8b208330ac1680a844405014