### PR TITLE
Add WLD payout on FAQ page

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,3 +2,4 @@ NEXT_PUBLIC_API_URL=http://localhost:3000
 NEXT_PUBLIC_WS_URL=ws://localhost:3000/ws
 # Comma separated origins allowed to request dev assets (e.g. from World App)
 ALLOWED_DEV_ORIGINS=http://localhost:3000,https://worldcoin.org
+NEXT_PUBLIC_WLD_ADDRESS=0xdc6ff44d5d932cbd77b52e5612ba0529dc6226f1

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -3,50 +3,33 @@
 import { useEffect, useState } from "react"
 import Link from "next/link"
 import { MiniKit } from "@worldcoin/minikit-js"
-import WLD_ABI from "../WLD_ABI.json"
-
-const WLD_TOKEN_ADDRESS = "0x4C34d508C19562f5020b7b6209aA3Ac1E0188c10"
-
-async function payoutUser(address: string) {
-  try {
-    const { finalPayload } = await MiniKit.commandsAsync.sendTransaction({
-      transaction: [
-        {
-          address: WLD_TOKEN_ADDRESS,
-          abi: WLD_ABI as any,
-          functionName: "transfer",
-          args: [address, "100000000000000000"],
-        },
-      ],
-    })
-
-    console.log("Transaktionstatus:", (finalPayload as any).status)
-  } catch (error) {
-    console.error("Auszahlung fehlgeschlagen", error)
-  }
-}
+import { payoutWLD } from "@/lib/payoutWld"
 
 export default function FAQPage() {
   const [userAddress, setUserAddress] = useState<string | null>(null)
   const [loadingAddress, setLoadingAddress] = useState(true)
   const [isVerified, setIsVerified] = useState(false)
+  const [claimed, setClaimed] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
 
   useEffect(() => {
     const fetchAddress = async () => {
       try {
-
-        if (typeof window !== 'undefined' && localStorage.getItem('worldIdVerified') === 'true') {
-          setIsVerified(true)
-        }
-
-        if (MiniKit.walletAddress) {
-          setUserAddress(MiniKit.walletAddress)
-          return
+        if (typeof window !== "undefined") {
+          if (localStorage.getItem("worldIdVerified") === "true") {
+            setIsVerified(true)
+          }
+          if (localStorage.getItem("wldPayoutDone") === "true") {
+            setClaimed(true)
+          }
         }
 
         const info = await MiniKit.getUserInfo()
-        if (info.walletAddress) {
-          setUserAddress(info.walletAddress)
+        if ((info as any).wallet_address) {
+          setUserAddress((info as any).wallet_address)
+        } else if ((info as any).walletAddress) {
+          setUserAddress((info as any).walletAddress)
         }
       } catch (err) {
         console.error("Nutzerinfo konnte nicht geladen werden", err)
@@ -58,24 +41,41 @@ export default function FAQPage() {
     fetchAddress()
   }, [])
 
+  const handlePayout = async () => {
+    if (!userAddress) return
+    setError(null)
+    try {
+      await payoutWLD(userAddress)
+      setClaimed(true)
+      setSuccess(true)
+      if (typeof window !== "undefined") {
+        localStorage.setItem("wldPayoutDone", "true")
+      }
+    } catch (err: any) {
+      console.error("Auszahlung fehlgeschlagen", err)
+      setError(err.message || "Transaktion abgelehnt")
+    }
+  }
+
   return (
     <main className="p-6 text-white">
       <h1 className="text-2xl font-bold mb-4">FAQ</h1>
       {loadingAddress ? (
         <p>Lade Nutzeradresse...</p>
-      ) : isVerified ? (
-        userAddress ? (
-          <button
-            onClick={() => payoutUser(userAddress)}
-            className="mb-4 px-6 py-3 bg-green-600 hover:bg-green-700 rounded text-white font-semibold"
-          >
-            0.1 WLD Test-Auszahlung starten
-          </button>
-        ) : (
-          <p>Nutzeradresse konnte nicht geladen werden.</p>
-        )
       ) : (
-        <p>Bitte einloggen oder verifizieren.</p>
+        <>
+          <button
+            disabled={!isVerified || claimed || !userAddress}
+            onClick={handlePayout}
+            className="mb-4 px-6 py-3 bg-green-600 rounded disabled:opacity-50"
+          >
+            0.1 WLD Preisgeld abholen
+          </button>
+          {success && <p className="text-green-400 mb-2">Auszahlung erfolgreich!</p>}
+          {error && <p className="text-red-400 mb-2">{error}</p>}
+          {!isVerified && <p>Bitte einloggen oder verifizieren.</p>}
+          {!userAddress && !error && <p>Nutzeradresse konnte nicht geladen werden.</p>}
+        </>
       )}
       <Link
         href="/"

--- a/src/abi/wldAbi.json
+++ b/src/abi/wldAbi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [
+      { "internalType": "bool", "name": "", "type": "bool" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/lib/payoutWld.ts
+++ b/src/lib/payoutWld.ts
@@ -1,0 +1,24 @@
+import { MiniKit } from '@worldcoin/minikit-js'
+import wldAbi from '@/abi/wldAbi.json'
+
+const WLD_ADDRESS = process.env.NEXT_PUBLIC_WLD_ADDRESS
+
+export async function payoutWLD(to: string, amountWld = 0.1): Promise<void> {
+  if (!WLD_ADDRESS) throw new Error('WLD token address missing')
+  const amountWei = BigInt(Math.round(amountWld * 1e18)).toString()
+
+  const { finalPayload } = await MiniKit.commandsAsync.sendTransaction({
+    transaction: [
+      {
+        address: WLD_ADDRESS,
+        abi: wldAbi as any,
+        functionName: 'transfer',
+        args: [to, amountWei],
+      },
+    ],
+  })
+
+  if ((finalPayload as any).status !== 'success') {
+    throw new Error('Transaction rejected')
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal transfer ABI for WLD
- provide payoutWLD helper using MiniKit sendTransaction
- update FAQ page with payout button and payout logic
- document WLD token address in env example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a2cc4a8cc8330aaabdc196c5234bb