### PR TITLE
Implement tx logging route

### DIFF
--- a/app/api/txlog/route.ts
+++ b/app/api/txlog/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const { txId, to, amount, error } = await req.json()
+
+  console.log('🪙 Neue Auszahlung:')
+  console.log('  TX-Hash  :', txId)
+  console.log('  Empfänger:', to)
+  console.log('  Betrag   :', amount, 'Wei')
+  if (error) {
+    console.log('  Fehler   :', error)
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/lib/payoutWld.ts
+++ b/src/lib/payoutWld.ts
@@ -5,20 +5,44 @@ const WLD_ADDRESS = process.env.NEXT_PUBLIC_WLD_ADDRESS
 
 export async function payoutWLD(to: string, amountWld = 0.1): Promise<void> {
   if (!WLD_ADDRESS) throw new Error('WLD token address missing')
-  const amountWei = BigInt(Math.round(amountWld * 1e18)).toString()
+  const wei = BigInt(Math.round(amountWld * 1e18)).toString()
 
-  const { finalPayload } = await MiniKit.commandsAsync.sendTransaction({
-    transaction: [
-      {
-        address: WLD_ADDRESS,
-        abi: wldAbi as any,
-        functionName: 'transfer',
-        args: [to, amountWei],
-      },
-    ],
-  })
+  try {
+    const { finalPayload } = await MiniKit.commandsAsync.sendTransaction({
+      transaction: [
+        {
+          address: WLD_ADDRESS,
+          abi: wldAbi as any,
+          functionName: 'transfer',
+          args: [to, wei],
+        },
+      ],
+    })
 
-  if ((finalPayload as any).status !== 'success') {
-    throw new Error('Transaction rejected')
+    await fetch('/api/txlog', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        txId: (finalPayload as any).transaction_id,
+        to,
+        amount: wei,
+      }),
+    })
+
+    if ((finalPayload as any).status !== 'success') {
+      throw new Error('Transaction rejected')
+    }
+  } catch (e: any) {
+    await fetch('/api/txlog', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        txId: 'ERROR',
+        to,
+        amount: wei,
+        error: e?.message ?? 'unknown',
+      }),
+    })
+    throw e
   }
 }


### PR DESCRIPTION
## Summary
- create `/api/txlog` endpoint for logging transactions
- log payout transaction results and errors via new route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cfa484e9483308fda3edc2c218fdc