### PR TITLE
Add test game contract integration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,3 +3,5 @@ NEXT_PUBLIC_WS_URL=ws://localhost:3000/ws
 # Comma separated origins allowed to request dev assets (e.g. from World App)
 ALLOWED_DEV_ORIGINS=http://localhost:3000,https://worldcoin.org
 NEXT_PUBLIC_WLD_ADDRESS=0xdc6ff44d5d932cbd77b52e5612ba0529dc6226f1
+# Adresse des WorldchessTest-Vertrags
+NEXT_PUBLIC_TEST_CONTRACT_ADDRESS=0xd9145CCE52D386f254917e481eB44e9943F39138

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import Link from "next/link"
 import { MiniKit } from "@worldcoin/minikit-js"
 import { payoutWLD } from "@/lib/payoutWld"
+import { createTestGame, settleTestGame } from "@/lib/testGame"
 
 export default function FAQPage() {
   const [userAddress, setUserAddress] = useState<string | null>(null)
@@ -12,6 +13,8 @@ export default function FAQPage() {
   const [claimed, setClaimed] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
+  const [testGameId, setTestGameId] = useState<string | null>(null)
+  const [txLoading, setTxLoading] = useState(false)
 
   useEffect(() => {
     const fetchAddress = async () => {
@@ -57,6 +60,40 @@ export default function FAQPage() {
     }
   }
 
+  const handleCreateTestGame = async () => {
+    if (!isVerified) {
+      setError('Bitte verifiziere dich über World ID.')
+      return
+    }
+    setTxLoading(true)
+    try {
+      const id = crypto.randomUUID().replace(/-/g, '')
+      await createTestGame(id)
+      setTestGameId(id)
+      setSuccess(true)
+    } catch (e: any) {
+      setError(e.message ?? 'Transaktion abgelehnt')
+    } finally {
+      setTxLoading(false)
+    }
+  }
+
+  const handleSettleTestGame = async () => {
+    if (!testGameId) {
+      setError('Es wurde noch kein Testspiel erstellt.')
+      return
+    }
+    setTxLoading(true)
+    try {
+      await settleTestGame(testGameId)
+      setSuccess(true)
+    } catch (e: any) {
+      setError(e.message ?? 'Transaktion abgelehnt oder kein Besitzer')
+    } finally {
+      setTxLoading(false)
+    }
+  }
+
   return (
     <main className="p-6 text-white">
       <h1 className="text-2xl font-bold mb-4">FAQ</h1>
@@ -67,9 +104,23 @@ export default function FAQPage() {
           <button
             disabled={!isVerified || claimed || !userAddress}
             onClick={handlePayout}
-            className="mb-4 px-6 py-3 bg-green-600 rounded disabled:opacity-50"
+            className="mb-4 px-6 py-2 bg-green-600 rounded disabled:opacity-50"
           >
             0.1 WLD Preisgeld abholen
+          </button>
+          <button
+            onClick={handleCreateTestGame}
+            disabled={txLoading || !isVerified}
+            className="mr-2 mb-4 px-4 py-2 rounded bg-green-600 text-white disabled:opacity-50"
+          >
+            Testspiel erstellen (0.2 WLD)
+          </button>
+          <button
+            onClick={handleSettleTestGame}
+            disabled={txLoading || !isVerified || !testGameId}
+            className="mb-4 px-4 py-2 rounded bg-purple-600 text-white disabled:opacity-50"
+          >
+            Testspiel auszahlen
           </button>
           {success && <p className="text-green-400 mb-2">Auszahlung erfolgreich!</p>}
           {error && <p className="text-red-400 mb-2">{error}</p>}

--- a/src/abi/testGameAbi.json
+++ b/src/abi/testGameAbi.json
@@ -1,0 +1,16 @@
+[
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_gameId", "type": "uint256" }],
+    "name": "depositTestGame",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_gameId", "type": "uint256" }],
+    "name": "payoutTestGame",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/abi/wldAbi.json
+++ b/src/abi/wldAbi.json
@@ -10,5 +10,17 @@
     ],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [
+      { "internalType": "bool", "name": "", "type": "bool" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
   }
 ]

--- a/src/lib/testGame.ts
+++ b/src/lib/testGame.ts
@@ -1,0 +1,46 @@
+import { MiniKit } from '@worldcoin/minikit-js';
+import wldAbi from '@/abi/wldAbi.json';
+import testAbi from '@/abi/testGameAbi.json';
+
+const WLD_ADDRESS = process.env.NEXT_PUBLIC_WLD_ADDRESS!;
+const TEST_CONTRACT = process.env.NEXT_PUBLIC_TEST_CONTRACT_ADDRESS || '0xd9145CCE52D386f254917e481eB44e9943F39138';
+
+// stake in WLD (0.2 WLD -> 10^18-Skalierung)
+const TEST_STAKE_WEI = BigInt(Math.floor(0.2 * 1e18)).toString();
+
+export async function createTestGame(gameId: number | string) {
+  if (!MiniKit.isInstalled()) throw new Error('MiniKit is not installed');
+  const idArg = BigInt(gameId).toString();
+  // erst Approve, dann deposit ausführen
+  await MiniKit.commandsAsync.sendTransaction({
+    transaction: [
+      {
+        address: WLD_ADDRESS,
+        abi: wldAbi as any,
+        functionName: 'approve',
+        args: [TEST_CONTRACT, TEST_STAKE_WEI],
+      },
+      {
+        address: TEST_CONTRACT,
+        abi: testAbi as any,
+        functionName: 'depositTestGame',
+        args: [idArg],
+      },
+    ],
+  });
+}
+
+export async function settleTestGame(gameId: number | string) {
+  if (!MiniKit.isInstalled()) throw new Error('MiniKit is not installed');
+  const idArg = BigInt(gameId).toString();
+  await MiniKit.commandsAsync.sendTransaction({
+    transaction: [
+      {
+        address: TEST_CONTRACT,
+        abi: testAbi as any,
+        functionName: 'payoutTestGame',
+        args: [idArg],
+      },
+    ],
+  });
+}


### PR DESCRIPTION
## Summary
- add minimal test game ABI
- extend WLD token ABI with approve
- add helper functions to create and settle a test game
- expose test contract address in env example
- add buttons and handlers on FAQ page for test game actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f48fb84c8330b9234b36fee0672f